### PR TITLE
Encapsulate ISqsQueue interface

### DIFF
--- a/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Handlers/OrderOnItsWayEventHandler.cs
+++ b/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Handlers/OrderOnItsWayEventHandler.cs
@@ -5,7 +5,7 @@ using JustSaying.Messaging.MessageHandling;
 using JustSaying.Sample.Restaurant.Models;
 using Microsoft.Extensions.Logging;
 
-namespace JustSaying.Sample.Restaurant.KitchenConsole
+namespace JustSaying.Sample.Restaurant.KitchenConsole.Handlers
 {
     public class OrderOnItsWayEventHandler : IHandlerAsync<OrderOnItsWayEvent>
     {

--- a/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Handlers/OrderPlacedEventHandler.cs
+++ b/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Handlers/OrderPlacedEventHandler.cs
@@ -6,7 +6,7 @@ using JustSaying.Messaging.MessageHandling;
 using JustSaying.Sample.Restaurant.Models;
 using Microsoft.Extensions.Logging;
 
-namespace JustSaying.Sample.Restaurant.KitchenConsole
+namespace JustSaying.Sample.Restaurant.KitchenConsole.Handlers
 {
     public class OrderPlacedEventHandler : IHandlerAsync<OrderPlacedEvent>
     {

--- a/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Program.cs
+++ b/samples/src/JustSaying.Sample.Restaurant.KitchenConsole/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using JustSaying.AwsTools;
+using JustSaying.Sample.Restaurant.KitchenConsole.Handlers;
 using JustSaying.Sample.Restaurant.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/src/JustSaying.Sample.Restaurant.OrderingApi/JustSaying.Sample.Restaurant.OrderingApi.csproj
+++ b/samples/src/JustSaying.Sample.Restaurant.OrderingApi/JustSaying.Sample.Restaurant.OrderingApi.csproj
@@ -8,6 +8,14 @@
     <NoWarn>$(NoWarn);CA2007</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <NoWarn>;CA1062;CA1303;CA2007;NU5105;CA1031</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <NoWarn>;CA1062;CA1303;CA2007;NU5105;CA1031</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.1-dev-00142" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />

--- a/src/JustSaying/AwsTools/MessageHandling/ISqsQueue.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/ISqsQueue.cs
@@ -14,10 +14,10 @@ namespace JustSaying.AwsTools.MessageHandling
 
         Uri Uri { get; }
 
-        Task<IList<Message>> GetMessagesAsync(int count, List<string> requestMessageAttributeNames, CancellationToken cancellationToken = default);
+        Task<IList<Message>> GetMessagesAsync(int count, IList<string> requestMessageAttributeNames, CancellationToken cancellationToken = default);
 
-        Task<ChangeMessageVisibilityResponse> ChangeMessageVisibilityAsync(ChangeMessageVisibilityRequest request, CancellationToken cancellationToken = default);
+        Task ChangeMessageVisibilityAsync(string receiptHandle, int timeoutInSeconds, CancellationToken cancellationToken = default);
 
-        Task<DeleteMessageResponse> DeleteMessageAsync(string receiptHandle, CancellationToken cancellationToken = default);
+        Task DeleteMessageAsync(string receiptHandle, CancellationToken cancellationToken = default);
     }
 }

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -173,8 +173,7 @@ namespace JustSaying.AwsTools.MessageHandling
             return RedrivePolicy.ConvertFromString(queueAttributes[JustSayingConstants.AttributeRedrivePolicy]);
         }
 
-        private static ServerSideEncryption ExtractServerSideEncryptionFromQueueAttributes(
-            Dictionary<string, string> queueAttributes)
+        private static ServerSideEncryption ExtractServerSideEncryptionFromQueueAttributes(Dictionary<string, string> queueAttributes)
         {
             if (!queueAttributes.ContainsKey(JustSayingConstants.AttributeEncryptionKeyId))
             {
@@ -184,8 +183,7 @@ namespace JustSaying.AwsTools.MessageHandling
             return new ServerSideEncryption
             {
                 KmsMasterKeyId = queueAttributes[JustSayingConstants.AttributeEncryptionKeyId],
-                KmsDataKeyReusePeriodSeconds =
-                    queueAttributes[JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId]
+                KmsDataKeyReusePeriodSeconds = queueAttributes[JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId]
             };
         }
 

--- a/src/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/SqsQueueBase.cs
@@ -68,16 +68,16 @@ namespace JustSaying.AwsTools.MessageHandling
         protected async Task SetQueuePropertiesAsync()
         {
             var keys = new[]
-            {
-                JustSayingConstants.AttributeArn,
-                JustSayingConstants.AttributeRedrivePolicy,
-                JustSayingConstants.AttributePolicy,
-                JustSayingConstants.AttributeRetentionPeriod,
-                JustSayingConstants.AttributeVisibilityTimeout,
-                JustSayingConstants.AttributeDeliveryDelay,
-                JustSayingConstants.AttributeEncryptionKeyId,
-                JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId
-            };
+                {
+                    JustSayingConstants.AttributeArn,
+                    JustSayingConstants.AttributeRedrivePolicy,
+                    JustSayingConstants.AttributePolicy,
+                    JustSayingConstants.AttributeRetentionPeriod,
+                    JustSayingConstants.AttributeVisibilityTimeout,
+                    JustSayingConstants.AttributeDeliveryDelay,
+                    JustSayingConstants.AttributeEncryptionKeyId,
+                    JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId
+                };
             var attributes = await GetAttrsAsync(keys).ConfigureAwait(false);
             Arn = attributes.QueueARN;
             MessageRetentionPeriod = TimeSpan.FromSeconds(attributes.MessageRetentionPeriod);
@@ -105,17 +105,15 @@ namespace JustSaying.AwsTools.MessageHandling
             {
                 var attributes = new Dictionary<string, string>
                 {
-                    {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetention.AsSecondsString()},
-                    {JustSayingConstants.AttributeVisibilityTimeout, queueConfig.VisibilityTimeout.AsSecondsString()},
-                    {JustSayingConstants.AttributeDeliveryDelay, queueConfig.DeliveryDelay.AsSecondsString()}
+                    {JustSayingConstants.AttributeRetentionPeriod, queueConfig.MessageRetention.AsSecondsString() },
+                    {JustSayingConstants.AttributeVisibilityTimeout, queueConfig.VisibilityTimeout.AsSecondsString() },
+                    {JustSayingConstants.AttributeDeliveryDelay, queueConfig.DeliveryDelay.AsSecondsString() }
                 };
 
                 if (queueConfig.ServerSideEncryption != null)
                 {
-                    attributes.Add(JustSayingConstants.AttributeEncryptionKeyId,
-                        queueConfig.ServerSideEncryption.KmsMasterKeyId);
-                    attributes.Add(JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId,
-                        queueConfig.ServerSideEncryption.KmsDataKeyReusePeriodSeconds);
+                    attributes.Add(JustSayingConstants.AttributeEncryptionKeyId, queueConfig.ServerSideEncryption.KmsMasterKeyId);
+                    attributes.Add(JustSayingConstants.AttributeEncryptionKeyReusePeriodSecondId, queueConfig.ServerSideEncryption.KmsDataKeyReusePeriodSeconds);
                 }
 
                 if (queueConfig.ServerSideEncryption == null)
@@ -159,8 +157,7 @@ namespace JustSaying.AwsTools.MessageHandling
             if (ServerSideEncryption != null && queueConfig.ServerSideEncryption != null)
             {
                 return ServerSideEncryption.KmsMasterKeyId != queueConfig.ServerSideEncryption.KmsMasterKeyId ||
-                       ServerSideEncryption.KmsDataKeyReusePeriodSeconds !=
-                       queueConfig.ServerSideEncryption.KmsDataKeyReusePeriodSeconds;
+                       ServerSideEncryption.KmsDataKeyReusePeriodSeconds != queueConfig.ServerSideEncryption.KmsDataKeyReusePeriodSeconds;
             }
 
             return true;

--- a/src/JustSaying/Messaging/Channels/QueueMessageContext.cs
+++ b/src/JustSaying/Messaging/Channels/QueueMessageContext.cs
@@ -24,14 +24,7 @@ namespace JustSaying.Messaging.Channels
 
         public async Task ChangeMessageVisibilityAsync(int visibilityTimeoutSeconds)
         {
-            var visibilityRequest = new ChangeMessageVisibilityRequest
-            {
-                QueueUrl = QueueUri.AbsoluteUri,
-                ReceiptHandle = Message.ReceiptHandle,
-                VisibilityTimeout = visibilityTimeoutSeconds
-            };
-
-            await SqsQueue.ChangeMessageVisibilityAsync(visibilityRequest).ConfigureAwait(false);
+            await SqsQueue.ChangeMessageVisibilityAsync(Message.ReceiptHandle, visibilityTimeoutSeconds).ConfigureAwait(false);
         }
 
         public Uri QueueUri => SqsQueue.Uri;


### PR DESCRIPTION
- Hide AWS types from ISqsQueue interface
- Renamespace handlers as they moved
- Suppress general exception handler error as we want to do that in Program to catch fatals