### PR TITLE
- Return consumer bus completion task at Start instead of a separate …

### DIFF
--- a/src/JustSaying/Messaging/Channels/ConsumerBus.cs
+++ b/src/JustSaying/Messaging/Channels/ConsumerBus.cs
@@ -38,25 +38,24 @@ namespace JustSaying.Messaging.Channels
                 .ToList();
         }
 
-        public void Start(CancellationToken stoppingToken)
+        public Task Start(CancellationToken stoppingToken)
         {
             var numberOfConsumers = _consumers.Count;
-            _logger.LogInformation("Starting up consumer bus with {ConsumerCount} consumers and {DownloadBufferCount} downloaders",
-                 numberOfConsumers, _buffers.Count);
+            _logger.LogInformation(
+                "Starting up consumer bus with {ConsumerCount} consumers and {DownloadBufferCount} downloaders",
+                numberOfConsumers, _buffers.Count);
 
             // start
-            var startTasks = new List<Task>();
-            startTasks.Add(_multiplexer.Start());
+            var completionTasks = new List<Task>();
+            completionTasks.Add(_multiplexer.Start());
 
-            startTasks.AddRange(_consumers.Select(x => x.Start()));
-            startTasks.AddRange(_buffers.Select(x => x.Start(stoppingToken)));
+            completionTasks.AddRange(_consumers.Select(x => x.Start()));
+            completionTasks.AddRange(_buffers.Select(x => x.Start(stoppingToken)));
 
             _logger.LogInformation("Consumer bus successfully started");
 
-            Completion = Task.WhenAll(startTasks);
+            return Task.WhenAll(completionTasks);
         }
-
-        public Task Completion { get; private set; }
 
         private IMessageReceiveBuffer CreateBuffer(
             ISqsQueue queue,

--- a/src/JustSaying/Messaging/Channels/IConsumerBus.cs
+++ b/src/JustSaying/Messaging/Channels/IConsumerBus.cs
@@ -5,7 +5,6 @@ namespace JustSaying.Messaging.Channels
 {
     public interface IConsumerBus
     {
-        void Start(CancellationToken stoppingToken);
-        Task Completion { get; }
+        Task Start(CancellationToken stoppingToken);
     }
 }

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
@@ -207,9 +207,7 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            bus.Start(cts.Token);
-
-            await bus.Completion;
+            await bus.Start(cts.Token);
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/BaseConsumerBusTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/BaseConsumerBusTests.cs
@@ -78,14 +78,14 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             HandlerMap.Add(typeof(SimpleMessage), msg => signallingHandler.Handle(msg as SimpleMessage));
 
             var cts = new CancellationTokenSource();
-            SystemUnderTest.Start(cts.Token);
+            var completion = SystemUnderTest.Start(cts.Token);
 
             // wait until it's done
             var doneOk = await TaskHelpers.WaitWithTimeoutAsync(doneSignal.Task);
 
             cts.Cancel();
 
-            await SystemUnderTest.Completion;
+            await completion;
 
             doneOk.ShouldBeTrue("Timeout occured before done signal");
         }

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenExactlyOnceIsAppliedToHandler.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenExactlyOnceIsAppliedToHandler.cs
@@ -51,13 +51,13 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             HandlerMap.Add(() => Handler);
 
             var cts = new CancellationTokenSource();
-            SystemUnderTest.Start(cts.Token);
+            var completion = SystemUnderTest.Start(cts.Token);
 
             // wait until it's done
             await TaskHelpers.WaitWithTimeoutAsync(_tcs.Task);
             cts.Cancel();
 
-            await SystemUnderTest.Completion;
+            await completion;
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -50,13 +50,13 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             HandlerMap.Add(() => Handler);
 
             var cts = new CancellationTokenSource();
-            SystemUnderTest.Start(cts.Token);
+            var completion = SystemUnderTest.Start(cts.Token);
 
             // wait until it's done
             await TaskHelpers.WaitWithTimeoutAsync(_tcs.Task);
             cts.Cancel();
 
-            await SystemUnderTest.Completion;
+            await completion;
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenListeningStartsAndStops.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenListeningStartsAndStops.cs
@@ -45,7 +45,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             _running = true;
             var cts = new CancellationTokenSource();
 
-            SystemUnderTest.Start(cts.Token);
+            var completion = SystemUnderTest.Start(cts.Token);
 
             // todo: should this be needed/should Start only complete when everything is running?
             await Task.Delay(TimeSpan.FromMilliseconds(100));
@@ -53,7 +53,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             _running = false;
             cts.Cancel();
 
-            await SystemUnderTest.Completion;
+            await completion;
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreExceptionsInMessageProcessing.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreExceptionsInMessageProcessing.cs
@@ -43,9 +43,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
-            SystemUnderTest.Start(cts.Token);
-
-            await SystemUnderTest.Completion;
+            await SystemUnderTest.Start(cts.Token);
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreExceptionsInSqsCalling.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreExceptionsInSqsCalling.cs
@@ -41,7 +41,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             {
                 throw new TestException("testing the failure on first call");
             }
-            
+
             return Task.FromResult(new List<Message>());
         }
 
@@ -50,9 +50,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
-            SystemUnderTest.Start(cts.Token);
-
-            await SystemUnderTest.Completion;
+            await SystemUnderTest.Start(cts.Token);
         }
 
         // todo: this one fails because we haven't handled this error yet

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreNoMessagesToProcess.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreNoMessagesToProcess.cs
@@ -39,9 +39,8 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
-            SystemUnderTest.Start(cts.Token);
+            await SystemUnderTest.Start(cts.Token);
 
-            await SystemUnderTest.Completion;
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ErrorHandlingTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ErrorHandlingTests.cs
@@ -37,9 +37,7 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            bus.Start(cts.Token);
-
-            await bus.Completion;
+            await bus.Start(cts.Token);
 
             messagesDispatched.ShouldBe(0);
         }


### PR DESCRIPTION
We currently return void from ConsumerBus.Start - we can probably just return the completion task directly here as the `void` indicates that users don't need to wait for the bus to start before continuing.