### PR TITLE
Fix cancellations

### DIFF
--- a/samples/src/JustSaying.Sample.Restaurant.OrderingApi/Program.cs
+++ b/samples/src/JustSaying.Sample.Restaurant.OrderingApi/Program.cs
@@ -8,7 +8,8 @@ using Serilog.Events;
 
 namespace JustSaying.Sample.Restaurant.OrderingApi
 {
-    [SuppressMessage("ReSharper", "CA1031")]
+    [SuppressMessage("ReSharper", "CA1031",
+        Justification = "We want to catch Exception so we can log fatals before shutting down")]
     public static class Program
     {
         public static void Main(string[] args)

--- a/src/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/SqsBasicConfiguration.cs
@@ -21,7 +21,7 @@ namespace JustSaying.AwsTools.QueueCreation
             DeliveryDelay = JustSayingConstants.MinimumDeliveryDelay;
         }
 
-        public virtual void Validate()
+        public void Validate()
         {
             if (MessageRetention < JustSayingConstants.MinimumRetentionPeriod ||
                 MessageRetention > JustSayingConstants.MaximumRetentionPeriod)
@@ -43,6 +43,10 @@ namespace JustSaying.AwsTools.QueueCreation
                 throw new ConfigurationErrorsException(
                     $"Invalid configuration. {nameof(DeliveryDelay)} must be between {JustSayingConstants.MinimumDeliveryDelay} and {JustSayingConstants.MaximumDeliveryDelay}.");
             }
+
+            ValidateCustom();
         }
+
+        protected virtual void ValidateCustom() {}
     }
 }

--- a/src/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/SqsReadConfiguration.cs
@@ -28,11 +28,10 @@ namespace JustSaying.AwsTools.QueueCreation
         public IMessageBackoffStrategy MessageBackoffStrategy { get; set; }
         public string FilterPolicy { get; set; }
 
-        public override void Validate()
+        protected override void ValidateCustom()
         {
             ValidateSnsConfiguration();
         }
-
 
         private void ValidateSnsConfiguration()
         {

--- a/src/JustSaying/AwsTools/QueueCreation/SqsWriteConfiguration.cs
+++ b/src/JustSaying/AwsTools/QueueCreation/SqsWriteConfiguration.cs
@@ -12,10 +12,8 @@ namespace JustSaying.AwsTools.QueueCreation
 
         public string QueueName { get; set; }
 
-        public override void Validate()
+        protected override void ValidateCustom()
         {
-            base.Validate();
-
             if (string.IsNullOrWhiteSpace(QueueName))
             {
                 throw new ConfigurationErrorsException("Invalid configuration. QueueName must be provided.");

--- a/src/JustSaying/JustSayingBus.cs
+++ b/src/JustSaying/JustSayingBus.cs
@@ -150,7 +150,7 @@ namespace JustSaying
                     dispatcher,
                     Monitor,
                     _loggerFactory);
-                ConsumerBus.Start(cancellationToken).GetAwaiter().GetResult();
+                ConsumerBus.Run(cancellationToken).GetAwaiter().GetResult();
             }
         }
 

--- a/src/JustSaying/Messaging/Channels/ConsumerBus.cs
+++ b/src/JustSaying/Messaging/Channels/ConsumerBus.cs
@@ -39,7 +39,7 @@ namespace JustSaying.Messaging.Channels
                 .ToList();
         }
 
-        public async Task Start(CancellationToken stoppingToken)
+        public Task Run(CancellationToken stoppingToken)
         {
             var numberOfConsumers = _consumers.Count;
             _logger.LogInformation(
@@ -49,18 +49,14 @@ namespace JustSaying.Messaging.Channels
             // start
             var completionTasks = new List<Task>();
 
-            await _multiplexer.Run(stoppingToken).ConfigureAwait(false);
-
-            completionTasks.Add(_multiplexer.Completion);
+            completionTasks.Add( _multiplexer.Run(stoppingToken));
             completionTasks.AddRange(_consumers.Select(x => x.Run(stoppingToken)));
             completionTasks.AddRange(_buffers.Select(x => x.Run(stoppingToken)));
 
             _logger.LogInformation("Consumer bus successfully started");
 
-            Completion = Task.WhenAll(completionTasks);
+            return Task.WhenAll(completionTasks);
         }
-
-        public Task Completion { get; private set; }
 
         private IMessageReceiveBuffer CreateBuffer(
             ISqsQueue queue,

--- a/src/JustSaying/Messaging/Channels/ConsumerBus.cs
+++ b/src/JustSaying/Messaging/Channels/ConsumerBus.cs
@@ -49,11 +49,11 @@ namespace JustSaying.Messaging.Channels
             // start
             var completionTasks = new List<Task>();
 
-            await _multiplexer.Start(stoppingToken).ConfigureAwait(false);
+            await _multiplexer.Run(stoppingToken).ConfigureAwait(false);
 
             completionTasks.Add(_multiplexer.Completion);
-            completionTasks.AddRange(_consumers.Select(x => x.Start(stoppingToken)));
-            completionTasks.AddRange(_buffers.Select(x => x.Start(stoppingToken)));
+            completionTasks.AddRange(_consumers.Select(x => x.Run(stoppingToken)));
+            completionTasks.AddRange(_buffers.Select(x => x.Run(stoppingToken)));
 
             _logger.LogInformation("Consumer bus successfully started");
 

--- a/src/JustSaying/Messaging/Channels/IChannelConsumer.cs
+++ b/src/JustSaying/Messaging/Channels/IChannelConsumer.cs
@@ -9,7 +9,7 @@ namespace JustSaying.Messaging.Channels
 {
     internal interface IChannelConsumer
     {
-        Task Start(CancellationToken stoppingToken);
+        Task Run(CancellationToken stoppingToken);
         IChannelConsumer ConsumeFrom(IAsyncEnumerable<IQueueMessageContext> messageSource);
     }
 
@@ -31,7 +31,7 @@ namespace JustSaying.Messaging.Channels
             return this;
         }
 
-        public async Task Start(CancellationToken stoppingToken)
+        public async Task Run(CancellationToken stoppingToken)
         {
             await foreach (var messageContext in _messageSource.WithCancellation(stoppingToken))
             {

--- a/src/JustSaying/Messaging/Channels/IConsumerBus.cs
+++ b/src/JustSaying/Messaging/Channels/IConsumerBus.cs
@@ -5,7 +5,6 @@ namespace JustSaying.Messaging.Channels
 {
     public interface IConsumerBus
     {
-        Task Start(CancellationToken stoppingToken);
-        Task Completion { get; }
+        Task Run(CancellationToken stoppingToken);
     }
 }

--- a/src/JustSaying/Messaging/Channels/IMessageReceiveBuffer.cs
+++ b/src/JustSaying/Messaging/Channels/IMessageReceiveBuffer.cs
@@ -6,7 +6,7 @@ namespace JustSaying.Messaging.Channels
 {
     internal interface IMessageReceiveBuffer
     {
-        Task Start(CancellationToken stoppingToken);
+        Task Run(CancellationToken stoppingToken);
         ChannelReader<IQueueMessageContext> Reader { get; }
     }
 }

--- a/src/JustSaying/Messaging/Channels/IMultiplexer.cs
+++ b/src/JustSaying/Messaging/Channels/IMultiplexer.cs
@@ -9,7 +9,7 @@ namespace JustSaying.Messaging.Channels
 {
     internal interface IMultiplexer
     {
-        Task Start(CancellationToken stoppingToken);
+        Task Run(CancellationToken stoppingToken);
         void ReadFrom(ChannelReader<IQueueMessageContext> reader);
         IAsyncEnumerable<IQueueMessageContext> Messages();
         Task Completion { get; }

--- a/src/JustSaying/Messaging/Channels/IMultiplexer.cs
+++ b/src/JustSaying/Messaging/Channels/IMultiplexer.cs
@@ -12,6 +12,5 @@ namespace JustSaying.Messaging.Channels
         Task Run(CancellationToken stoppingToken);
         void ReadFrom(ChannelReader<IQueueMessageContext> reader);
         IAsyncEnumerable<IQueueMessageContext> Messages();
-        Task Completion { get; }
     }
 }

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
@@ -48,13 +48,13 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Run(cts.Token);
-
+            var multiplexerCompletion = multiplexer.Run(cts.Token);
             var consumer1Completion = consumer.Run(cts.Token);
             var buffer1Completion = buffer.Run(cts.Token);
 
-            await Assert.ThrowsAsync<OperationCanceledException>(() =>
-                Task.WhenAll(multiplexer.Completion, consumer1Completion, buffer1Completion));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => multiplexerCompletion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer1Completion);
         }
 
         [Fact]
@@ -79,16 +79,18 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Run(cts.Token);
+            var multiplexerCompletion = multiplexer.Run(cts.Token);
 
             // consumers
-            var t1 = consumer1.Run(cts.Token);
-            var t2 = consumer2.Run(cts.Token);
+            var consumer1Completion = consumer1.Run(cts.Token);
+            var consumer2Completion = consumer2.Run(cts.Token);
 
-            var completion = buffer.Run(cts.Token);
+            var buffer1Completion = buffer.Run(cts.Token);
 
-            await Assert.ThrowsAsync<OperationCanceledException>(
-                () => Task.WhenAll(multiplexer.Completion, t1, t2, completion));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => multiplexerCompletion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer2Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer1Completion);
         }
 
         [Fact]
@@ -114,7 +116,7 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Run(cts.Token);
+            var multiplexerCompletion = multiplexer.Run(cts.Token);
 
             // consumers
             var consumer1Completion = consumer.Run(cts.Token);
@@ -122,10 +124,10 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var buffer1Completion = buffer1.Run(cts.Token);
             var buffer2Completion = buffer2.Run(cts.Token);
 
-            await Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
-            await Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
-            await Assert.ThrowsAsync<OperationCanceledException>(() => buffer2Completion);
-            await Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => multiplexerCompletion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer2Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer1Completion);
         }
 
         [Fact]
@@ -152,11 +154,10 @@ namespace JustSaying.UnitTests.Messaging.Channels
             consumer1.ConsumeFrom(multiplexer.Messages());
             consumer2.ConsumeFrom(multiplexer.Messages());
 
-
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Run(cts.Token);
+            var multiplexerCompletion = multiplexer.Run(cts.Token);
 
             // consumers
             var consumer1Completion = consumer1.Run(cts.Token);
@@ -165,11 +166,11 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var buffer1Completion = buffer1.Run(cts.Token);
             var buffer2Completion = buffer2.Run(cts.Token);
 
-            Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => buffer2Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => consumer2Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer2Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer2Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => multiplexerCompletion);
 
         }
 
@@ -194,16 +195,15 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Run(cts.Token);
+            var multiplexerCompletion = multiplexer.Run(cts.Token);
 
             // consumer
             var consumer1Completion = consumer.Run(cts.Token);
-
             var buffer1Completion = buffer.Run(cts.Token);
 
-            Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => multiplexerCompletion);
 
             messagesDispatched.ShouldBe(messagesFromQueue);
         }
@@ -223,7 +223,7 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await bus.Start(cts.Token);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => bus.Run(cts.Token));
         }
 
         [Fact]
@@ -262,7 +262,7 @@ namespace JustSaying.UnitTests.Messaging.Channels
             consumer3.ConsumeFrom(multiplexer.Messages());
 
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            await multiplexer.Run(cts.Token);
+            var multiplexerCompletion = multiplexer.Run(cts.Token);
 
             // consumers
             var consumer1Completion = consumer1.Run(cts.Token);
@@ -274,14 +274,14 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var buffer3Completion = buffer3.Run(cts.Token);
             var buffer4Completion = buffer4.Run(cts.Token);
 
-            Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => buffer2Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => buffer3Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => buffer4Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => consumer2Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => consumer3Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer2Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer3Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer4Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer2Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer3Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => multiplexerCompletion);
 
             _testOutputHelper.WriteLine("Attempted to send {0} messages and dispatched {1} messages", messagesSent,
                 messagesDispatched);
@@ -309,7 +309,7 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Run(cts.Token);
+            var multiplexerCompletion = multiplexer.Run(cts.Token);
 
             var buffer1Completion = buffer.Run(cts.Token);
 
@@ -318,9 +318,9 @@ namespace JustSaying.UnitTests.Messaging.Channels
 
             var consumer1Completion = consumer.Run(cts.Token);
 
-            Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
-            Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => buffer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => consumer1Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => multiplexerCompletion);
 
             messagesFromQueue.ShouldBe(111);
             messagesDispatched.ShouldBe(111);

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
@@ -48,10 +48,10 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Start(cts.Token);
+            await multiplexer.Run(cts.Token);
 
-            var consumer1Completion = consumer.Start(cts.Token);
-            var buffer1Completion = buffer.Start(cts.Token);
+            var consumer1Completion = consumer.Run(cts.Token);
+            var buffer1Completion = buffer.Run(cts.Token);
 
             await Assert.ThrowsAsync<OperationCanceledException>(() =>
                 Task.WhenAll(multiplexer.Completion, consumer1Completion, buffer1Completion));
@@ -79,13 +79,13 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Start(cts.Token);
+            await multiplexer.Run(cts.Token);
 
             // consumers
-            var t1 = consumer1.Start(cts.Token);
-            var t2 = consumer2.Start(cts.Token);
+            var t1 = consumer1.Run(cts.Token);
+            var t2 = consumer2.Run(cts.Token);
 
-            var completion = buffer.Start(cts.Token);
+            var completion = buffer.Run(cts.Token);
 
             await Assert.ThrowsAsync<OperationCanceledException>(
                 () => Task.WhenAll(multiplexer.Completion, t1, t2, completion));
@@ -114,19 +114,18 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Start(cts.Token);
+            await multiplexer.Run(cts.Token);
 
             // consumers
-            var consumer1Completion = consumer.Start(cts.Token);
+            var consumer1Completion = consumer.Run(cts.Token);
 
-            var buffer1Completion = buffer1.Start(cts.Token);
-            var buffer2Completion = buffer2.Start(cts.Token);
+            var buffer1Completion = buffer1.Run(cts.Token);
+            var buffer2Completion = buffer2.Run(cts.Token);
 
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await multiplexer.Completion);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await buffer1Completion);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await buffer2Completion);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await consumer1Completion);
-
+            await Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => buffer2Completion);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
         }
 
         [Fact]
@@ -157,18 +156,21 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Start(cts.Token);
+            await multiplexer.Run(cts.Token);
 
             // consumers
-            var consumer1Completion = consumer1.Start(cts.Token);
-            var consumer2Completion = consumer2.Start(cts.Token);
+            var consumer1Completion = consumer1.Run(cts.Token);
+            var consumer2Completion = consumer2.Run(cts.Token);
 
-            var buffer1Completion = buffer1.Start(cts.Token);
-            var buffer2Completion = buffer2.Start(cts.Token);
+            var buffer1Completion = buffer1.Run(cts.Token);
+            var buffer2Completion = buffer2.Run(cts.Token);
 
-            await Assert.ThrowsAsync<OperationCanceledException>(() =>
-                Task.WhenAll(buffer1Completion, buffer2Completion, consumer1Completion, consumer2Completion,
-                    multiplexer.Completion));
+            Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => buffer2Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => consumer2Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
+
         }
 
         [Fact]
@@ -192,15 +194,16 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Start(cts.Token);
+            await multiplexer.Run(cts.Token);
 
             // consumer
-            var consumer1Completion = consumer.Start(cts.Token);
+            var consumer1Completion = consumer.Run(cts.Token);
 
-            var bufferCompletion = buffer.Start(cts.Token);
+            var buffer1Completion = buffer.Run(cts.Token);
 
-            await Assert.ThrowsAsync<OperationCanceledException>(() =>
-                Task.WhenAll(bufferCompletion, consumer1Completion, multiplexer.Completion));
+            Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
 
             messagesDispatched.ShouldBe(messagesFromQueue);
         }
@@ -259,20 +262,26 @@ namespace JustSaying.UnitTests.Messaging.Channels
             consumer3.ConsumeFrom(multiplexer.Messages());
 
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            await multiplexer.Start(cts.Token);
+            await multiplexer.Run(cts.Token);
 
             // consumers
-            var t1 = consumer1.Start(cts.Token);
-            var t2 = consumer2.Start(cts.Token);
-            var t3 = consumer3.Start(cts.Token);
+            var consumer1Completion = consumer1.Run(cts.Token);
+            var consumer2Completion = consumer2.Run(cts.Token);
+            var consumer3Completion = consumer3.Run(cts.Token);
 
-            var writeTask1 = buffer1.Start(cts.Token);
-            var writeTask2 = buffer2.Start(cts.Token);
-            var writeTask3 = buffer3.Start(cts.Token);
-            var writeTask4 = buffer4.Start(cts.Token);
+            var buffer1Completion = buffer1.Run(cts.Token);
+            var buffer2Completion = buffer2.Run(cts.Token);
+            var buffer3Completion = buffer3.Run(cts.Token);
+            var buffer4Completion = buffer4.Run(cts.Token);
 
-            Assert.ThrowsAsync<OperationCanceledException>(() =>
-                Task.WhenAll(writeTask1, writeTask2, writeTask3, writeTask4, t1, t2, t3, multiplexer.Completion));
+            Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => buffer2Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => buffer3Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => buffer4Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => consumer2Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => consumer3Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
 
             _testOutputHelper.WriteLine("Attempted to send {0} messages and dispatched {1} messages", messagesSent,
                 messagesDispatched);
@@ -300,17 +309,18 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await multiplexer.Start(cts.Token);
+            await multiplexer.Run(cts.Token);
 
-            var bufferCompletion = buffer.Start(cts.Token);
+            var buffer1Completion = buffer.Run(cts.Token);
 
             messagesFromQueue.ShouldBe(111);
             messagesDispatched.ShouldBe(0);
 
-            var consumer1Completion = consumer.Start(cts.Token);
+            var consumer1Completion = consumer.Run(cts.Token);
 
-            Assert.ThrowsAsync<OperationCanceledException>(() =>
-                Task.WhenAll(bufferCompletion, consumer1Completion, multiplexer.Completion));
+            Assert.ThrowsAsync<OperationCanceledException>(() => buffer1Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => consumer1Completion);
+            Assert.ThrowsAsync<OperationCanceledException>(() => multiplexer.Completion);
 
             messagesFromQueue.ShouldBe(111);
             messagesDispatched.ShouldBe(111);

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/BaseConsumerBusTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/BaseConsumerBusTests.cs
@@ -78,7 +78,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             HandlerMap.Add(typeof(SimpleMessage), msg => signallingHandler.Handle(msg as SimpleMessage));
 
             var cts = new CancellationTokenSource();
-            var completion = SystemUnderTest.Start(cts.Token);
+            var completion = SystemUnderTest.Run(cts.Token);
 
             // wait until it's done
             var doneOk = await TaskHelpers.WaitWithTimeoutAsync(doneSignal.Task);

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenExactlyOnceIsAppliedToHandler.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenExactlyOnceIsAppliedToHandler.cs
@@ -51,7 +51,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             HandlerMap.Add(() => Handler);
 
             var cts = new CancellationTokenSource();
-            await SystemUnderTest.Start(cts.Token);
+            await SystemUnderTest.Run(cts.Token);
 
             // wait until it's done
             await TaskHelpers.WaitWithTimeoutAsync(_tcs.Task);

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenExactlyOnceIsAppliedToHandlerWithoutExplicitTimeout.cs
@@ -50,7 +50,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             HandlerMap.Add(() => Handler);
 
             var cts = new CancellationTokenSource();
-            await SystemUnderTest.Start(cts.Token);
+            await SystemUnderTest.Run(cts.Token);
 
             // wait until it's done
             await TaskHelpers.WaitWithTimeoutAsync(_tcs.Task);

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenListeningStartsAndStops.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenListeningStartsAndStops.cs
@@ -45,7 +45,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             _running = true;
             var cts = new CancellationTokenSource();
 
-            await SystemUnderTest.Start(cts.Token);
+            await SystemUnderTest.Run(cts.Token);
 
             // todo: should this be needed/should Start only complete when everything is running?
             await Task.Delay(TimeSpan.FromMilliseconds(100));

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreExceptionsInMessageProcessing.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreExceptionsInMessageProcessing.cs
@@ -43,7 +43,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
-            await SystemUnderTest.Start(cts.Token);
+            await SystemUnderTest.Run(cts.Token);
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreExceptionsInSqsCalling.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreExceptionsInSqsCalling.cs
@@ -50,9 +50,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(1));
 
-            await SystemUnderTest.Start(cts.Token);
-
-            await Assert.ThrowsAsync<OperationCanceledException>(() => SystemUnderTest.Completion);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => SystemUnderTest.Run(cts.Token));
         }
 
         // todo: this one fails because we haven't handled this error yet

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreNoMessagesToProcess.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/WhenThereAreNoMessagesToProcess.cs
@@ -39,10 +39,7 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromMilliseconds(100));
 
-            await SystemUnderTest.Start(cts.Token);
-
-            await SystemUnderTest.Completion;
-
+            await SystemUnderTest.Run(cts.Token);
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ErrorHandlingTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ErrorHandlingTests.cs
@@ -37,7 +37,7 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(2));
 
-            await bus.Start(cts.Token);
+            await bus.Run(cts.Token);
 
             messagesDispatched.ShouldBe(0);
         }


### PR DESCRIPTION
- Remove use of ContinueWith
- Rename methods that return a completion task Run
- Refactor out completion tasks from ConsumerBus (multiplexer has a sync lock on start instead of async now)
- Rework cancellations so that OperationCancelled is always thrown on cancellation, and assert it in all tests.
- Rework Validate on SqsReadConfiguration so base.Validate() call isn't necessary.