### PR TITLE
Immutable consumer group settings

### DIFF
--- a/src/JustSaying/Messaging/Channels/Configuration/ConsumerGroupConfig.cs
+++ b/src/JustSaying/Messaging/Channels/Configuration/ConsumerGroupConfig.cs
@@ -25,16 +25,6 @@ namespace JustSaying.Messaging.Channels.Configuration
         public int DefaultConsumerCount { get; set; }
         public int DefaultMultiplexerCapacity { get; set; }
 
-        public ConsumerGroupSettings CreateConsumerGroupSettings(IList<ISqsQueue> sqsQueues = null)
-        {
-            return new ConsumerGroupSettings(
-                DefaultConsumerCount,
-                DefaultBufferSize,
-                DefaultMultiplexerCapacity,
-                DefaultPrefetch,
-                sqsQueues);
-        }
-
         public MiddlewareBase<GetMessagesContext, IList<Amazon.SQS.Model.Message>> SqsMiddleware { get; private set; }
             = new DelegateMiddleware<GetMessagesContext, IList<Amazon.SQS.Model.Message>>();
 

--- a/src/JustSaying/Messaging/Channels/ConsumerGroups/CombinedConsumerGroup.cs
+++ b/src/JustSaying/Messaging/Channels/ConsumerGroups/CombinedConsumerGroup.cs
@@ -13,14 +13,14 @@ namespace JustSaying.Messaging.Channels.ConsumerGroups
 
         public CombinedConsumerGroup(
             IConsumerGroupFactory groupFactory,
-            IDictionary<string, ConsumerGroupSettings> consumerGroupSettings,
+            IDictionary<string, ConsumerGroupSettingsBuilder> consumerGroupSettings,
             ILogger<CombinedConsumerGroup> logger)
         {
             _logger = logger;
 
             _buses = consumerGroupSettings
                 .Values
-                .Select(settings => groupFactory.Create(settings)).ToList();
+                .Select(groupFactory.Create).ToList();
         }
 
         private Task _completion;

--- a/src/JustSaying/Messaging/Channels/ConsumerGroups/ConsumerGroupSettings.cs
+++ b/src/JustSaying/Messaging/Channels/ConsumerGroups/ConsumerGroupSettings.cs
@@ -1,37 +1,28 @@
 using System.Collections.Generic;
-using System.Linq;
 using JustSaying.AwsTools.MessageHandling;
 
 namespace JustSaying.Messaging.Channels.ConsumerGroups
 {
-    public class ConsumerGroupSettings
+    internal class ConsumerGroupSettings
     {
-        private readonly List<ISqsQueue> _sqsQueues;
-
-        public ConsumerGroupSettings(
-            int bufferSize,
+        internal ConsumerGroupSettings(
             int consumerCount,
+            int bufferSize,
             int multiplexerCapacity,
             int prefetch,
-            IList<ISqsQueue> sqsQueues = null)
+            IReadOnlyList<ISqsQueue> queues)
         {
-            BufferSize = bufferSize;
             ConsumerCount = consumerCount;
+            BufferSize = bufferSize;
             MultiplexerCapacity = multiplexerCapacity;
             Prefetch = prefetch;
-            _sqsQueues = sqsQueues?.ToList() ?? new List<ISqsQueue>();
-        }
-
-        public void AddQueue(ISqsQueue sqsQueue)
-        {
-            _sqsQueues.Add(sqsQueue);
+            Queues = queues;
         }
 
         public int ConsumerCount { get; }
         public int BufferSize { get; }
         public int MultiplexerCapacity { get; }
         public int Prefetch { get; }
-
-        public IReadOnlyList<ISqsQueue> Queues => _sqsQueues;
+        public IReadOnlyList<ISqsQueue> Queues { get; }
     }
 }

--- a/src/JustSaying/Messaging/Channels/ConsumerGroups/ConsumerGroupSettingsBuilder.cs
+++ b/src/JustSaying/Messaging/Channels/ConsumerGroups/ConsumerGroupSettingsBuilder.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using JustSaying.AwsTools.MessageHandling;
+
+namespace JustSaying.Messaging.Channels.ConsumerGroups
+{
+    public class ConsumerGroupSettingsBuilder
+    {
+        private readonly List<ISqsQueue> _sqsQueues;
+
+        public ConsumerGroupSettingsBuilder()
+        {
+            _sqsQueues = new List<ISqsQueue>();
+        }
+
+        public ConsumerGroupSettingsBuilder AddQueue(ISqsQueue sqsQueue)
+        {
+            _sqsQueues.Add(sqsQueue);
+            return this;
+        }
+
+        public ConsumerGroupSettingsBuilder AddQueues(IEnumerable<ISqsQueue> sqsQueues)
+        {
+            _sqsQueues.AddRange(sqsQueues);
+            return this;
+        }
+
+        private int _consumerCount;
+
+        public ConsumerGroupSettingsBuilder WithConsumerCount(int consumerCount)
+        {
+            _consumerCount = consumerCount;
+            return this;
+        }
+
+        private int _bufferSize;
+
+        public ConsumerGroupSettingsBuilder WithBufferSize(int bufferSize)
+        {
+            _bufferSize = bufferSize;
+            return this;
+        }
+
+        private int _multiplexerCapacity;
+
+        public ConsumerGroupSettingsBuilder WithMultiplexerCapacity(int multiplexerCapacity)
+        {
+            _multiplexerCapacity = multiplexerCapacity;
+            return this;
+        }
+
+        private int _prefetch;
+
+        public ConsumerGroupSettingsBuilder WithPrefetch(int prefetch)
+        {
+            _prefetch = prefetch;
+            return this;
+        }
+
+        internal ConsumerGroupSettings Build()
+        {
+            return new ConsumerGroupSettings(_consumerCount,
+                _bufferSize,
+                _multiplexerCapacity,
+                _prefetch,
+                _sqsQueues);
+        }
+    }
+}

--- a/src/JustSaying/Messaging/Channels/ConsumerGroups/IConsumerGroupFactory.cs
+++ b/src/JustSaying/Messaging/Channels/ConsumerGroups/IConsumerGroupFactory.cs
@@ -2,6 +2,6 @@ namespace JustSaying.Messaging.Channels.ConsumerGroups
 {
     internal interface IConsumerGroupFactory
     {
-        IConsumerGroup Create(ConsumerGroupSettings consumerGroupSettings);
+        IConsumerGroup Create(ConsumerGroupSettingsBuilder settingsBuilder);
     }
 }

--- a/src/JustSaying/Messaging/Channels/Receive/IReceiveBufferFactory.cs
+++ b/src/JustSaying/Messaging/Channels/Receive/IReceiveBufferFactory.cs
@@ -8,7 +8,7 @@ namespace JustSaying.Messaging.Channels.Receive
 {
     internal interface IReceiveBufferFactory
     {
-        IMessageReceiveBuffer CreateBuffer(ISqsQueue queue, ConsumerGroupSettings settings);
+        IMessageReceiveBuffer CreateBuffer(ISqsQueue queue, ConsumerGroupSettings consumerGroupSettings);
     }
 
     internal class ReceiveBufferFactory : IReceiveBufferFactory
@@ -27,10 +27,10 @@ namespace JustSaying.Messaging.Channels.Receive
             _monitor = monitor;
         }
 
-        public IMessageReceiveBuffer CreateBuffer(ISqsQueue queue, ConsumerGroupSettings settings)
+        public IMessageReceiveBuffer CreateBuffer(ISqsQueue queue, ConsumerGroupSettings consumerGroupSettings)
         {
             var buffer = new MessageReceiveBuffer(
-                settings.BufferSize,
+                consumerGroupSettings.BufferSize,
                 queue,
                 _consumerGroupConfig.SqsMiddleware,
                 _monitor,

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
@@ -347,10 +347,9 @@ namespace JustSaying.UnitTests.Messaging.Channels
             IMessageDispatcher dispatcher)
         {
             var config = new ConsumerGroupConfig();
-            var consumerGroupSettings = config.CreateConsumerGroupSettings(queues);
-            var settings = new Dictionary<string, ConsumerGroupSettings>
+            var settings = new Dictionary<string, ConsumerGroupSettingsBuilder>
             {
-                { "test", consumerGroupSettings },
+                { "test", new ConsumerGroupSettingsBuilder().AddQueues(queues) },
             };
 
             var receiveBufferFactory = new ReceiveBufferFactory(LoggerFactory, config, MessageMonitor);

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/BaseConsumerBusTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ConsumerBusTests/BaseConsumerBusTests.cs
@@ -26,7 +26,6 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
     public abstract class BaseConsumerBusTests : IAsyncLifetime
     {
         protected IList<ISqsQueue> Queues;
-        protected int NumberOfConsumers;
         protected HandlerMap HandlerMap;
         protected IMessageMonitor Monitor;
         protected SimpleMessage DeserializedMessage;
@@ -65,7 +64,6 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
         private void GivenInternal()
         {
             Queues = new List<ISqsQueue>();
-            NumberOfConsumers = 1;
             Handler = Substitute.For<IHandlerAsync<SimpleMessage>>();
             Monitor = Substitute.For<IMessageMonitor>();
             SerializationRegister = Substitute.For<IMessageSerializationRegister>();
@@ -123,10 +121,9 @@ namespace JustSaying.UnitTests.Messaging.Channels.ConsumerBusTests
             var consumerBusFactory = new SingleConsumerGroupFactory(
                 multiplexerFactory, receiveBufferFactory, consumerFactory, LoggerFactory);
 
-            var consumerGroupSettings = config.CreateConsumerGroupSettings(Queues);
-            var settings = new Dictionary<string, ConsumerGroupSettings>
+            var settings = new Dictionary<string, ConsumerGroupSettingsBuilder>
             {
-                { "test", consumerGroupSettings },
+                { "test", new ConsumerGroupSettingsBuilder().AddQueues(Queues) },
             };
 
             var bus = new CombinedConsumerGroup(

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ErrorHandlingTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ErrorHandlingTests.cs
@@ -49,10 +49,9 @@ namespace JustSaying.UnitTests.Messaging.Channels
 
             var config = new ConsumerGroupConfig();
             config.WithDefaultSqsPolicy(LoggerFactory);
-            var consumerGroupSettings = config.CreateConsumerGroupSettings(queues);
-            var settings = new Dictionary<string, ConsumerGroupSettings>
+            var settings = new Dictionary<string, ConsumerGroupSettingsBuilder>
             {
-                { "test", consumerGroupSettings },
+                { "test", new ConsumerGroupSettingsBuilder().AddQueues(queues) },
             };
 
             var receiveBufferFactory = new ReceiveBufferFactory(LoggerFactory, config, MessageMonitor);

--- a/tests/JustSaying.UnitTests/Messaging/Policies/ChannelPolicyTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Policies/ChannelPolicyTests.cs
@@ -51,10 +51,9 @@ namespace JustSaying.UnitTests.Messaging.Policies
             config.WithSqsPolicy(
                 next =>
                     new ErrorHandlingMiddleware<GetMessagesContext, IList<Message>, InvalidOperationException>(next));
-            var consumerGroupSettings = config.CreateConsumerGroupSettings(queues);
-            var settings = new Dictionary<string, ConsumerGroupSettings>
+            var settings = new Dictionary<string, ConsumerGroupSettingsBuilder>
             {
-                { "test", consumerGroupSettings },
+                { "test", new ConsumerGroupSettingsBuilder().AddQueues(queues) },
             };
 
             IMessageDispatcher dispatcher = new FakeDispatcher(() => Interlocked.Increment(ref dispatchedMessageCount));


### PR DESCRIPTION
- Introduce builder for individual consumer group's settings.
- Builder is created with defaults, which will be exposed via the main fluent API for updates
- ConsumerGroupSettings is now immutable and created from the builder when needed.