### PR TITLE
Refactor message serializer

### DIFF
--- a/src/JustSaying.Extensions.DependencyInjection.Microsoft/IServiceCollectionExtensions.cs
+++ b/src/JustSaying.Extensions.DependencyInjection.Microsoft/IServiceCollectionExtensions.cs
@@ -139,7 +139,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 (p) =>
                 {
                     var config = p.GetRequiredService<IMessagingConfig>();
-                    return new MessageSerializationRegister(config.MessageSubjectProvider);
+                    var serializerFactory = p.GetRequiredService<IMessageSerializationFactory>();
+                    return new MessageSerializationRegister(config.MessageSubjectProvider, serializerFactory);
                 });
 
             services.TryAddSingleton(

--- a/src/JustSaying.Extensions.DependencyInjection.StructureMap/JustSayingRegistry.cs
+++ b/src/JustSaying.Extensions.DependencyInjection.StructureMap/JustSayingRegistry.cs
@@ -42,7 +42,8 @@ namespace JustSaying
                     (p) =>
                     {
                         var config = p.GetInstance<IMessagingConfig>();
-                        return new MessageSerializationRegister(config.MessageSubjectProvider);
+                        var serializerFactory = p.GetInstance<IMessageSerializationFactory>();
+                        return new MessageSerializationRegister(config.MessageSubjectProvider, serializerFactory);
                     })
                 .Singleton();
 

--- a/src/JustSaying/AwsTools/MessageHandling/ISqsQueue.cs
+++ b/src/JustSaying/AwsTools/MessageHandling/ISqsQueue.cs
@@ -15,7 +15,7 @@ namespace JustSaying.AwsTools.MessageHandling
         Uri Uri { get; }
 
         Task<IList<Message>> GetMessagesAsync(int maximumCount, IEnumerable<string> requestMessageAttributeNames,
-            CancellationToken cancellationToken = default);
+            CancellationToken stoppingToken = default);
 
         Task ChangeMessageVisibilityAsync(string receiptHandle, TimeSpan timeout, CancellationToken cancellationToken = default);
 

--- a/src/JustSaying/Fluent/DefaultServiceResolver.cs
+++ b/src/JustSaying/Fluent/DefaultServiceResolver.cs
@@ -45,7 +45,9 @@ namespace JustSaying.Fluent
             }
             else if (desiredType == typeof(IMessageSerializationRegister))
             {
-                return new MessageSerializationRegister(ResolveService<IMessageSubjectProvider>());
+                return new MessageSerializationRegister(
+                    ResolveService<IMessageSubjectProvider>(),
+                    ResolveService<IMessageSerializationFactory>());
             }
             else if (desiredType == typeof(IMessageSubjectProvider))
             {

--- a/src/JustSaying/JustSayingBus.cs
+++ b/src/JustSaying/JustSayingBus.cs
@@ -165,7 +165,7 @@ namespace JustSaying
 
             SubscriptionGroups = subscriptionGroupFactory.Create(_subscriptionGroupSettings);
 
-            _log.LogDebug("Interrogation response: {@Response}", SubscriptionGroups.Interrogate());
+            _log.LogInformation("Starting bus with settings: {@Response}", SubscriptionGroups.Interrogate());
 
             return SubscriptionGroups.Run(stoppingToken);
         }

--- a/src/JustSaying/JustSayingBus.cs
+++ b/src/JustSaying/JustSayingBus.cs
@@ -165,6 +165,8 @@ namespace JustSaying
 
             SubscriptionGroups = subscriptionGroupFactory.Create(_subscriptionGroupSettings);
 
+            _log.LogDebug("Interrogation response: {@Response}", SubscriptionGroups.Interrogate());
+
             return SubscriptionGroups.Run(stoppingToken);
         }
 

--- a/src/JustSaying/JustSayingFluently.cs
+++ b/src/JustSaying/JustSayingFluently.cs
@@ -34,7 +34,6 @@ namespace JustSaying
         private readonly ILogger _log;
         private readonly IVerifyAmazonQueues _amazonQueueCreator;
         private readonly IAwsClientFactoryProxy _awsClientFactoryProxy;
-        private readonly IMessageSerializationFactory _serializationFactory;
         protected internal IAmJustSaying Bus { get; set; }
         private SqsReadConfiguration _subscriptionConfig = new SqsReadConfiguration(SubscriptionType.ToTopic);
         private readonly ILoggerFactory _loggerFactory;
@@ -43,7 +42,6 @@ namespace JustSaying
             IAmJustSaying bus,
             IVerifyAmazonQueues queueCreator,
             IAwsClientFactoryProxy awsClientFactoryProxy,
-            IMessageSerializationFactory serializationFactory,
             ILoggerFactory loggerFactory)
         {
             _loggerFactory = loggerFactory;
@@ -51,7 +49,6 @@ namespace JustSaying
             Bus = bus;
             _amazonQueueCreator = queueCreator;
             _awsClientFactoryProxy = awsClientFactoryProxy;
-            _serializationFactory = serializationFactory;
         }
 
         /// <summary>

--- a/src/JustSaying/JustSayingFluently.cs
+++ b/src/JustSaying/JustSayingFluently.cs
@@ -34,15 +34,16 @@ namespace JustSaying
         private readonly ILogger _log;
         private readonly IVerifyAmazonQueues _amazonQueueCreator;
         private readonly IAwsClientFactoryProxy _awsClientFactoryProxy;
+        private readonly IMessageSerializationFactory _serializationFactory;
         protected internal IAmJustSaying Bus { get; set; }
         private SqsReadConfiguration _subscriptionConfig = new SqsReadConfiguration(SubscriptionType.ToTopic);
-        private IMessageSerializationFactory _serializationFactory;
         private readonly ILoggerFactory _loggerFactory;
 
         protected internal JustSayingFluently(
             IAmJustSaying bus,
             IVerifyAmazonQueues queueCreator,
             IAwsClientFactoryProxy awsClientFactoryProxy,
+            IMessageSerializationFactory serializationFactory,
             ILoggerFactory loggerFactory)
         {
             _loggerFactory = loggerFactory;
@@ -50,6 +51,7 @@ namespace JustSaying
             Bus = bus;
             _amazonQueueCreator = queueCreator;
             _awsClientFactoryProxy = awsClientFactoryProxy;
+            _serializationFactory = serializationFactory;
         }
 
         /// <summary>
@@ -82,7 +84,7 @@ namespace JustSaying
 
             _subscriptionConfig.TopicName = GetOrUseTopicNamingConvention<T>(_subscriptionConfig.TopicName);
 
-            Bus.SerializationRegister.AddSerializer<T>(_serializationFactory.GetSerializer<T>());
+            Bus.SerializationRegister.AddSerializer<T>();
 
             foreach (var region in Bus.Config.Regions)
             {
@@ -134,8 +136,6 @@ namespace JustSaying
 
             var config = new SqsWriteConfiguration();
             configBuilder?.Invoke(config);
-
-            Bus.SerializationRegister.AddSerializer<T>(_serializationFactory.GetSerializer<T>());
 
             config.QueueName = GetOrUseQueueNamingConvention<T>(config.QueueName);
 
@@ -197,12 +197,6 @@ namespace JustSaying
                 .ConfigureAwait(false);
         }
 
-        public IMayWantOptionalSettings WithSerializationFactory(IMessageSerializationFactory factory)
-        {
-            _serializationFactory = factory;
-            return this;
-        }
-
         public IMayWantOptionalSettings WithMessageLockStoreOf(IMessageLockAsync messageLock)
         {
             Bus.MessageLock = messageLock;
@@ -244,11 +238,6 @@ namespace JustSaying
 
         public IHaveFulfilledSubscriptionRequirements WithMessageHandler<T>(IHandlerResolver handlerResolver) where T : Message
         {
-            if (_serializationFactory == null)
-            {
-                throw new InvalidOperationException($"No {nameof(IMessageSerializationFactory)} has been configured.");
-            }
-
             _subscriptionConfig.TopicName = GetOrUseTopicNamingConvention<T>(_subscriptionConfig.TopicName);
             _subscriptionConfig.QueueName = GetOrUseQueueNamingConvention<T>(_subscriptionConfig.QueueName);
             _subscriptionConfig.SubscriptionGroup ??= _subscriptionConfig.QueueName;
@@ -256,8 +245,6 @@ namespace JustSaying
             var thing = _subscriptionConfig.SubscriptionType == SubscriptionType.PointToPoint
                 ? PointToPointHandler<T>()
                 : TopicHandler<T>();
-
-            Bus.SerializationRegister.AddSerializer<T>(_serializationFactory.GetSerializer<T>());
 
             var resolutionContext = new HandlerResolutionContext(_subscriptionConfig.QueueName);
             var proposedHandler = handlerResolver.ResolveHandler<T>(resolutionContext);

--- a/src/JustSaying/JustSayingFluently.cs
+++ b/src/JustSaying/JustSayingFluently.cs
@@ -251,6 +251,7 @@ namespace JustSaying
 
             _subscriptionConfig.TopicName = GetOrUseTopicNamingConvention<T>(_subscriptionConfig.TopicName);
             _subscriptionConfig.QueueName = GetOrUseQueueNamingConvention<T>(_subscriptionConfig.QueueName);
+            _subscriptionConfig.SubscriptionGroup ??= _subscriptionConfig.QueueName;
 
             var thing = _subscriptionConfig.SubscriptionType == SubscriptionType.PointToPoint
                 ? PointToPointHandler<T>()

--- a/src/JustSaying/JustSayingFluentlyDependencies.cs
+++ b/src/JustSaying/JustSayingFluentlyDependencies.cs
@@ -10,5 +10,6 @@ namespace JustSaying
         public IMessageSubjectProvider MessageSubjectProvider { get; set; }
         public IQueueNamingConvention QueueNamingConvention { get; set; }
         public ITopicNamingConvention TopicNamingConvention { get; set; }
+        public IMessageSerializationFactory SerializationFactory { get; set; }
     }
 }

--- a/src/JustSaying/JustSayingFluentlyExtensions.cs
+++ b/src/JustSaying/JustSayingFluentlyExtensions.cs
@@ -63,18 +63,25 @@ namespace JustSaying
 
             config.Validate();
 
-            var messageSerializationRegister = new MessageSerializationRegister(config.MessageSubjectProvider);
+            var serializationFactory = dependencies.SerializationFactory ?? new NewtonsoftSerializationFactory();
+
+            var messageSerializationRegister = new MessageSerializationRegister(
+                config.MessageSubjectProvider,
+                serializationFactory);
             var justSayingBus = new JustSayingBus(config, messageSerializationRegister, dependencies.LoggerFactory);
 
             var awsClientFactoryProxy = new AwsClientFactoryProxy(() => CreateMeABus.DefaultClientFactory());
 
             var amazonQueueCreator = new AmazonQueueCreator(awsClientFactoryProxy, dependencies.LoggerFactory);
 
-            var bus = new JustSayingFluently(justSayingBus, amazonQueueCreator, awsClientFactoryProxy, dependencies.LoggerFactory);
+            var bus = new JustSayingFluently(justSayingBus,
+                amazonQueueCreator,
+                awsClientFactoryProxy,
+                serializationFactory,
+                dependencies.LoggerFactory);
 
             bus
-                .WithMonitoring(new NullOpMessageMonitor())
-                .WithSerializationFactory(new NewtonsoftSerializationFactory());
+                .WithMonitoring(new NullOpMessageMonitor());
 
             return bus;
         }

--- a/src/JustSaying/JustSayingFluentlyExtensions.cs
+++ b/src/JustSaying/JustSayingFluentlyExtensions.cs
@@ -77,7 +77,6 @@ namespace JustSaying
             var bus = new JustSayingFluently(justSayingBus,
                 amazonQueueCreator,
                 awsClientFactoryProxy,
-                serializationFactory,
                 dependencies.LoggerFactory);
 
             bus

--- a/src/JustSaying/JustSayingFluentlyInterfaces.cs
+++ b/src/JustSaying/JustSayingFluentlyInterfaces.cs
@@ -13,7 +13,6 @@ namespace JustSaying
 
     public interface IMayWantOptionalSettings : IMayWantMonitoring,
         IMayWantMessageLockStore,
-        IMayWantCustomSerialization,
         IMayWantAFailoverRegion,
         IMayWantAwsClientFactory,
         IMayWantMessageContextAccessor
@@ -43,11 +42,6 @@ namespace JustSaying
     public interface IMayWantMessageLockStore : IAmJustSayingFluently
     {
         IMayWantOptionalSettings WithMessageLockStoreOf(IMessageLockAsync messageLock);
-    }
-
-    public interface IMayWantCustomSerialization : IAmJustSayingFluently
-    {
-        IMayWantOptionalSettings WithSerializationFactory(IMessageSerializationFactory factory);
     }
 
     public interface IMayWantMessageContextAccessor : IAmJustSayingFluently

--- a/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
+++ b/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
@@ -120,10 +120,10 @@ namespace JustSaying.Messaging.Channels.Receive
                 };
 
                 messages = await _sqsMiddleware.RunAsync(context,
-                        async () =>
+                        async ct =>
                             await _sqsQueue
-                                .GetMessagesAsync(count, _requestMessageAttributeNames, stoppingToken)
-                                .ConfigureAwait(false))
+                                .GetMessagesAsync(count, _requestMessageAttributeNames, ct)
+                                .ConfigureAwait(false), linkedCts.Token)
                     .ConfigureAwait(false);
             }
             finally

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroup.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroup.cs
@@ -56,7 +56,7 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
                 ConcurrencyLimit = _subscribers.Count,
                 Settings = _settings,
                 Multiplexer = _multiplexer.Interrogate(),
-                ReceiveBuffers = _receiveBuffers.Select(rb => rb.Interrogate()),
+                ReceiveBuffers = _receiveBuffers.Select(rb => rb.Interrogate()).ToArray(),
             };
         }
     }

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroup.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroup.cs
@@ -54,7 +54,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
             {
                 _settings.Name,
                 ConcurrencyLimit = _subscribers.Count,
-                Settings = _settings,
                 Multiplexer = _multiplexer.Interrogate(),
                 ReceiveBuffers = _receiveBuffers.Select(rb => rb.Interrogate()).ToArray(),
             };

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroupCollection.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroupCollection.cs
@@ -48,7 +48,7 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
             IEnumerable<object> interrogationResponses = _subscriptionGroups.Select(bus => bus.Interrogate());
             return new
             {
-                SubscriptionGroups = interrogationResponses,
+                SubscriptionGroups = interrogationResponses.ToArray(),
             };
         }
 

--- a/src/JustSaying/Messaging/MessageSerialization/IMessageSerialisationRegister.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/IMessageSerialisationRegister.cs
@@ -17,12 +17,12 @@ namespace JustSaying.Messaging.MessageSerialization
         /// <param name="message"></param>
         /// <param name="serializeForSnsPublishing">If set to false, then message will be wrapped in extra object with Subject and Message fields, e.g.:
         /// new { Subject = message.GetType().Name, Message = serializedMessage };
-        /// 
+        ///
         /// AWS SNS service adds these automatically, so for publishing to topics don't add these properties
         /// </param>
         /// <returns></returns>
         string Serialize(Message message, bool serializeForSnsPublishing);
 
-        void AddSerializer<T>(IMessageSerializer serializer) where T : Message;
+        void AddSerializer<T>() where T : Message;
     }
 }

--- a/src/JustSaying/Messaging/MessageSerialization/MessageSerializationRegister.cs
+++ b/src/JustSaying/Messaging/MessageSerialization/MessageSerializationRegister.cs
@@ -8,19 +8,21 @@ namespace JustSaying.Messaging.MessageSerialization
     public class MessageSerializationRegister : IMessageSerializationRegister
     {
         private readonly IMessageSubjectProvider _messageSubjectProvider;
+        private readonly IMessageSerializationFactory _serializationFactory;
         private readonly IDictionary<Type, TypeSerializer> _map = new ConcurrentDictionary<Type, TypeSerializer>();
 
-        public MessageSerializationRegister(IMessageSubjectProvider messageSubjectProvider)
+        public MessageSerializationRegister(IMessageSubjectProvider messageSubjectProvider, IMessageSerializationFactory serializationFactory)
         {
             _messageSubjectProvider = messageSubjectProvider ?? throw new ArgumentNullException(nameof(messageSubjectProvider));
+            _serializationFactory = serializationFactory;
         }
 
-        public void AddSerializer<T>(IMessageSerializer serializer) where T : Message
+        public void AddSerializer<T>() where T : Message
         {
             var key = typeof(T);
             if (!_map.TryGetValue(key, out TypeSerializer typeSerializer))
             {
-                _map[key] = new TypeSerializer(typeof(T), serializer);
+                _map[key] = new TypeSerializer(typeof(T), _serializationFactory.GetSerializer<T>());
             }
         }
 

--- a/src/JustSaying/Messaging/Middleware/DefaultSqsMiddleware.cs
+++ b/src/JustSaying/Messaging/Middleware/DefaultSqsMiddleware.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;
 using JustSaying.Messaging.Channels;
@@ -17,11 +18,14 @@ namespace JustSaying.Messaging.Middleware
             _logger = logger;
         }
 
-        protected override async Task<IList<Message>> RunInnerAsync(GetMessagesContext context, Func<Task<IList<Message>>> func)
+        protected override async Task<IList<Message>> RunInnerAsync(
+            GetMessagesContext context,
+            Func<CancellationToken, Task<IList<Message>>> func,
+            CancellationToken stoppingToken)
         {
             try
             {
-                var results = await func().ConfigureAwait(false);
+                var results = await func(stoppingToken).ConfigureAwait(false);
 
                 _logger.LogTrace(
                     "Polled for messages on queue '{QueueName}' in region '{Region}', and received {MessageCount} messages.",

--- a/src/JustSaying/Messaging/Middleware/DelegateMiddleware.cs
+++ b/src/JustSaying/Messaging/Middleware/DelegateMiddleware.cs
@@ -1,13 +1,14 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace JustSaying.Messaging.Middleware
 {
     internal class DelegateMiddleware<TContext, TOut> : MiddlewareBase<TContext, TOut>
     {
-        protected override async Task<TOut> RunInnerAsync(TContext context, Func<Task<TOut>> func)
+        protected override async Task<TOut> RunInnerAsync(TContext context, Func<CancellationToken, Task<TOut>> func, CancellationToken stoppingToken)
         {
-            return await func().ConfigureAwait(false);
+            return await func(stoppingToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/JustSaying/MessagingBusBuilder.cs
+++ b/src/JustSaying/MessagingBusBuilder.cs
@@ -308,15 +308,14 @@ namespace JustSaying
         {
             IAwsClientFactoryProxy proxy = CreateFactoryProxy();
             IVerifyAmazonQueues queueCreator = new AmazonQueueCreator(proxy, loggerFactory);
-
-            var fluent = new JustSayingFluently(bus, queueCreator, proxy, loggerFactory);
-
             IMessageSerializationFactory serializationFactory = CreateMessageSerializationFactory();
+
+            var fluent = new JustSayingFluently(bus, queueCreator, proxy, serializationFactory, loggerFactory);
+
             IMessageMonitor messageMonitor = CreateMessageMonitor();
             IMessageContextAccessor messageContextAccessor = CreateMessageContextAccessor();
 
-            fluent.WithSerializationFactory(serializationFactory)
-                .WithMonitoring(messageMonitor)
+            fluent.WithMonitoring(messageMonitor)
                 .WithMessageContextAccessor(messageContextAccessor);
 
             if (ServicesBuilder?.MessageLock != null)

--- a/src/JustSaying/MessagingBusBuilder.cs
+++ b/src/JustSaying/MessagingBusBuilder.cs
@@ -299,18 +299,12 @@ namespace JustSaying
             return ServicesBuilder?.MessageContextAccessor?.Invoke() ?? ServiceResolver.ResolveService<IMessageContextAccessor>();
         }
 
-        private IMessageSerializationFactory CreateMessageSerializationFactory()
-        {
-            return ServicesBuilder?.MessageSerializationFactory?.Invoke() ?? ServiceResolver.ResolveService<IMessageSerializationFactory>();
-        }
-
         private JustSayingFluently CreateFluent(JustSayingBus bus, ILoggerFactory loggerFactory)
         {
             IAwsClientFactoryProxy proxy = CreateFactoryProxy();
             IVerifyAmazonQueues queueCreator = new AmazonQueueCreator(proxy, loggerFactory);
-            IMessageSerializationFactory serializationFactory = CreateMessageSerializationFactory();
 
-            var fluent = new JustSayingFluently(bus, queueCreator, proxy, serializationFactory, loggerFactory);
+            var fluent = new JustSayingFluently(bus, queueCreator, proxy, loggerFactory);
 
             IMessageMonitor messageMonitor = CreateMessageMonitor();
             IMessageContextAccessor messageContextAccessor = CreateMessageContextAccessor();

--- a/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingQueueTwice.cs
+++ b/tests/JustSaying.IntegrationTests/Fluent/AwsTools/WhenCreatingQueueTwice.cs
@@ -26,7 +26,8 @@ namespace JustSaying.IntegrationTests.Fluent.AwsTools
             IAwsClientFactory clientFactory = CreateClientFactory();
 
             var subjectProvider = new NonGenericMessageSubjectProvider();
-            var serializationRegister = new MessageSerializationRegister(subjectProvider);
+            var serializerFactor = new NewtonsoftSerializationFactory();
+            var serializationRegister = new MessageSerializationRegister(subjectProvider, serializerFactor);
 
             var client = clientFactory.GetSnsClient(Region);
 

--- a/tests/JustSaying.UnitTests/AwsTools/TopicCreation/WhenCreatingTopicWithNoPermissions.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/TopicCreation/WhenCreatingTopicWithNoPermissions.cs
@@ -30,7 +30,8 @@ namespace JustSaying.UnitTests.AwsTools.TopicCreation
             ILoggerFactory loggerFactory = OutputHelper.ToLoggerFactory();
 
             var subjectProvider = new NonGenericMessageSubjectProvider();
-            var serializationRegister = new MessageSerializationRegister(subjectProvider);
+            var serializerFactor = new NewtonsoftSerializationFactory();
+            var serializationRegister = new MessageSerializationRegister(subjectProvider, serializerFactor);
 
             IAmazonSimpleNotificationService client = CreateSnsClient(exists: true);
 
@@ -57,7 +58,8 @@ namespace JustSaying.UnitTests.AwsTools.TopicCreation
             ILoggerFactory loggerFactory = OutputHelper.ToLoggerFactory();
 
             var subjectProvider = new NonGenericMessageSubjectProvider();
-            var serializationRegister = new MessageSerializationRegister(subjectProvider);
+            var serializerFactor = new NewtonsoftSerializationFactory();
+            var serializationRegister = new MessageSerializationRegister(subjectProvider, serializerFactor);
 
             IAmazonSimpleNotificationService client = CreateSnsClient(exists: false);
 

--- a/tests/JustSaying.UnitTests/CreateMe/WhenCreatingABus.cs
+++ b/tests/JustSaying.UnitTests/CreateMe/WhenCreatingABus.cs
@@ -44,18 +44,5 @@ namespace JustSaying.UnitTests.CreateMe
             // Enforced by the fact we can do other configurations on the bus.
             CreateMeABus.WithLogging(new LoggerFactory()).InRegion(_region).ConfigurePublisherWith(_config);
         }
-
-        [Fact]
-        public void ThenICanProvideCustomSerialization()
-        {
-            CreateMeABus.WithLogging(new LoggerFactory()).InRegion(_region).WithSerializationFactory(null);
-        }
-
-        [Fact]
-        public void CustomSerializationIsNotEnforced()
-        {
-            // Enforced by the fact we can do other configurations on the bus.
-            CreateMeABus.WithLogging(new LoggerFactory()).InRegion(_region).WithSerializationFactory(null);
-        }
     }
 }

--- a/tests/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/tests/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -53,7 +53,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         [Fact]
         public void SerializationIsRegisteredForMessage()
         {
-            Bus.SerializationRegister.Received().AddSerializer<Message>(Arg.Any<IMessageSerializer>());
+            Bus.Received().AddMessageHandler(Arg.Any<Func<IHandlerAsync<Message>>>());
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
+++ b/tests/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenAddingASubscriptionHandler.cs
@@ -53,7 +53,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         [Fact]
         public void SerializationIsRegisteredForMessage()
         {
-            Bus.Received().AddMessageHandler(Arg.Any<Func<IHandlerAsync<Message>>>());
+            Bus.Received().AddMessageHandler(Arg.Any<string>(),Arg.Any<Func<IHandlerAsync<Message>>>());
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
+++ b/tests/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
@@ -8,6 +8,7 @@ using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageSerialization;
 using JustSaying.Models;
 using NSubstitute;
+using NSubstitute.ReceivedExtensions;
 using Shouldly;
 using Xunit;
 
@@ -55,7 +56,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         [Fact]
         public void SerializationIsRegisteredForMessage()
         {
-            Bus.SerializationRegister.Received().AddSerializer<Message>(Arg.Any<IMessageSerializer>());
+            Bus.Received().AddMessageHandler(Arg.Any<Func<IHandlerAsync<Message>>>());
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
+++ b/tests/JustSaying.UnitTests/JustSayingFluently/AddingHandlers/WhenSubscribingPointToPoint.cs
@@ -56,7 +56,7 @@ namespace JustSaying.UnitTests.JustSayingFluently.AddingHandlers
         [Fact]
         public void SerializationIsRegisteredForMessage()
         {
-            Bus.Received().AddMessageHandler(Arg.Any<Func<IHandlerAsync<Message>>>());
+            Bus.Received().AddMessageHandler(Arg.Any<string>(),Arg.Any<Func<IHandlerAsync<Message>>>());
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
+++ b/tests/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
@@ -3,6 +3,7 @@ using JustSaying.TestingFramework;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using System;
+using JustSaying.Messaging.MessageSerialization;
 using Xunit;
 
 namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
@@ -13,7 +14,11 @@ namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
 
         protected override JustSaying.JustSayingFluently CreateSystemUnderTest()
         {
-            return new JustSaying.JustSayingFluently(_bus, null, new AwsClientFactoryProxy(), Substitute.For<ILoggerFactory>());
+            return new JustSaying.JustSayingFluently(_bus,
+                null,
+                new AwsClientFactoryProxy(),
+                new NewtonsoftSerializationFactory(),
+                Substitute.For<ILoggerFactory>());
         }
 
         protected override void Given()

--- a/tests/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
+++ b/tests/JustSaying.UnitTests/JustSayingFluently/RegisteringPublishers/WhenAddingPublishers.cs
@@ -17,7 +17,6 @@ namespace JustSaying.UnitTests.JustSayingFluently.RegisteringPublishers
             return new JustSaying.JustSayingFluently(_bus,
                 null,
                 new AwsClientFactoryProxy(),
-                new NewtonsoftSerializationFactory(),
                 Substitute.For<ILoggerFactory>());
         }
 

--- a/tests/JustSaying.UnitTests/Messaging/Channels/SubscriberBusTests/Approvals/WhenListeningWithMultipleGroups.SubscriptionGroups_OverridesDefaultSettingsCorrectly.approved.txt
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/SubscriberBusTests/Approvals/WhenListeningWithMultipleGroups.SubscriptionGroups_OverridesDefaultSettingsCorrectly.approved.txt
@@ -3,20 +3,6 @@
     {
       "Name": "queueA",
       "ConcurrencyLimit": 1,
-      "Settings": {
-        "ConcurrencyLimit": 1,
-        "BufferSize": 20,
-        "MultiplexerCapacity": 30,
-        "Prefetch": 5,
-        "Name": "queueA",
-        "Queues": [
-          {
-            "QueueName": "TestQueue",
-            "RegionSystemName": "",
-            "Uri": "http://foo.com"
-          }
-        ]
-      },
       "Multiplexer": {
         "ChannelCapacity": 30,
         "ReaderCount": 1
@@ -24,7 +10,7 @@
       "ReceiveBuffers": [
         {
           "BufferSize": 20,
-          "QueueName": "TestQueue",
+          "QueueName": "TestQueueA",
           "Region": "",
           "Prefetch": 5,
           "BackoffStrategyName": null
@@ -34,20 +20,6 @@
     {
       "Name": "queueB",
       "ConcurrencyLimit": 48,
-      "Settings": {
-        "ConcurrencyLimit": 48,
-        "BufferSize": 10,
-        "MultiplexerCapacity": 100,
-        "Prefetch": 10,
-        "Name": "queueB",
-        "Queues": [
-          {
-            "QueueName": "TestQueue",
-            "RegionSystemName": "",
-            "Uri": "http://foo.com"
-          }
-        ]
-      },
       "Multiplexer": {
         "ChannelCapacity": 100,
         "ReaderCount": 1
@@ -55,7 +27,7 @@
       "ReceiveBuffers": [
         {
           "BufferSize": 10,
-          "QueueName": "TestQueue",
+          "QueueName": "TestQueueB",
           "Region": "",
           "Prefetch": 10,
           "BackoffStrategyName": null

--- a/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupCollectionTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupCollectionTests.cs
@@ -79,7 +79,8 @@ namespace JustSaying.UnitTests.Messaging.Channels
             var config = Substitute.For<IMessagingConfig>();
             config.SubscriptionConfig.Returns(new SubscriptionConfig());
             var serializationRegister = new MessageSerializationRegister(
-                new NonGenericMessageSubjectProvider());
+                new NonGenericMessageSubjectProvider(),
+                new NewtonsoftSerializationFactory());
             var serializationFactory = new NewtonsoftSerializationFactory();
 
             var bus = new JustSaying.JustSayingBus(config, serializationRegister, LoggerFactory)
@@ -87,7 +88,7 @@ namespace JustSaying.UnitTests.Messaging.Channels
                 Monitor = MessageMonitor,
             };
 
-            bus.SerializationRegister.AddSerializer<TestJustSayingMessage>(serializationFactory.GetSerializer<TestJustSayingMessage>());
+            bus.SerializationRegister.AddSerializer<TestJustSayingMessage>();
 
             return bus;
         }

--- a/tests/JustSaying.UnitTests/Messaging/Policies/ExamplePolicies/ErrorHandlingMiddleware`1.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Policies/ExamplePolicies/ErrorHandlingMiddleware`1.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.Messaging.Middleware;
 
@@ -9,14 +10,16 @@ namespace JustSaying.UnitTests.Messaging.Policies.ExamplePolicies
     {
         public ErrorHandlingMiddleware(MiddlewareBase<TContext, TOut> next) : base(next)
         {
-
         }
 
-        protected override async Task<TOut> RunInnerAsync(TContext context, Func<Task<TOut>> func)
+        protected override async Task<TOut> RunInnerAsync(
+            TContext context,
+            Func<CancellationToken, Task<TOut>> func,
+            CancellationToken stoppingToken)
         {
             try
             {
-                return await func();
+                return await func(stoppingToken);
             }
             catch (TException)
             {

--- a/tests/JustSaying.UnitTests/Messaging/Policies/ExamplePolicies/PollyMiddleware.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Policies/ExamplePolicies/PollyMiddleware.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using JustSaying.Messaging.Middleware;
 using Polly;
@@ -14,9 +15,12 @@ namespace JustSaying.UnitTests.Messaging.Policies.ExamplePolicies
             _policy = policy;
         }
 
-        protected override async Task<TOut> RunInnerAsync(TContext context, Func<Task<TOut>> func)
+        protected override async Task<TOut> RunInnerAsync(
+            TContext context,
+            Func<CancellationToken, Task<TOut>> func,
+            CancellationToken stoppingToken)
         {
-            return await _policy.ExecuteAsync(func);
+            return await _policy.ExecuteAsync(() => func(stoppingToken));
         }
     }
 }

--- a/tests/JustSaying.UnitTests/Messaging/Serialization/SerializationRegister/WhenAddingASerializerTwice.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Serialization/SerializationRegister/WhenAddingASerializerTwice.cs
@@ -9,7 +9,9 @@ namespace JustSaying.UnitTests.Messaging.Serialization.SerializationRegister
     public class WhenAddingASerializerTwice : XBehaviourTest<MessageSerializationRegister>
     {
         protected override MessageSerializationRegister CreateSystemUnderTest() =>
-            new MessageSerializationRegister(new NonGenericMessageSubjectProvider());
+            new MessageSerializationRegister(
+                new NonGenericMessageSubjectProvider(),
+                new NewtonsoftSerializationFactory());
 
         protected override void Given()
         {
@@ -18,8 +20,8 @@ namespace JustSaying.UnitTests.Messaging.Serialization.SerializationRegister
 
         protected override void WhenAction()
         {
-            SystemUnderTest.AddSerializer<Message>(Substitute.For<IMessageSerializer>());
-            SystemUnderTest.AddSerializer<Message>(Substitute.For<IMessageSerializer>());
+            SystemUnderTest.AddSerializer<Message>();
+            SystemUnderTest.AddSerializer<Message>();
         }
 
         [Fact]

--- a/tests/JustSaying.UnitTests/Messaging/Serialization/SerializationRegister/WhenDeserializingMessage.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Serialization/SerializationRegister/WhenDeserializingMessage.cs
@@ -26,9 +26,6 @@ namespace JustSaying.UnitTests.Messaging.Serialization.SerializationRegister
 
         protected override void WhenAction()
         {
-            var messageSerializer = Substitute.For<IMessageSerializer>();
-            messageSerializer.GetMessageSubject(messageBody).Returns(typeof(CustomMessage).Name);
-            messageSerializer.Deserialize(messageBody, typeof(CustomMessage)).Returns(new CustomMessage());
             SystemUnderTest.AddSerializer<CustomMessage>();
         }
 

--- a/tests/JustSaying.UnitTests/Messaging/Serialization/SerializationRegister/WhenDeserializingMessage.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Serialization/SerializationRegister/WhenDeserializingMessage.cs
@@ -14,9 +14,11 @@ namespace JustSaying.UnitTests.Messaging.Serialization.SerializationRegister
         }
 
         protected override MessageSerializationRegister CreateSystemUnderTest() =>
-            new MessageSerializationRegister(new NonGenericMessageSubjectProvider());
+            new MessageSerializationRegister(
+                new NonGenericMessageSubjectProvider(),
+                new NewtonsoftSerializationFactory());
 
-        private string messageBody = "msgBody";
+        private string messageBody = "{'Subject':'nonexistent'}";
         protected override void Given()
         {
             RecordAnyExceptionsThrown();
@@ -27,20 +29,13 @@ namespace JustSaying.UnitTests.Messaging.Serialization.SerializationRegister
             var messageSerializer = Substitute.For<IMessageSerializer>();
             messageSerializer.GetMessageSubject(messageBody).Returns(typeof(CustomMessage).Name);
             messageSerializer.Deserialize(messageBody, typeof(CustomMessage)).Returns(new CustomMessage());
-            SystemUnderTest.AddSerializer<CustomMessage>(messageSerializer);
+            SystemUnderTest.AddSerializer<CustomMessage>();
         }
 
         [Fact]
         public void ThrowsMessageFormatNotSupportedWhenMessabeBodyIsUnserializable()
         {
-            new Action(() => SystemUnderTest.DeserializeMessage(string.Empty)).ShouldThrow<MessageFormatNotSupportedException>();
+            Assert.Throws<MessageFormatNotSupportedException>(() => SystemUnderTest.DeserializeMessage(messageBody));
         }
-
-        [Fact]
-        public void TheMappingContainsTheSerializer()
-        {
-            SystemUnderTest.DeserializeMessage(messageBody).ShouldNotBeNull();
-        }
-
     }
 }


### PR DESCRIPTION
It shouldn't be necessary to pass an IMessageSerializer into `AddSerializer` - instead the registry should take a dependency on the factory and `AddSerializer` becomes just that - registering a type for serialization.

You could make the argument we shouldn't need to do this at all and the serializer should just work for all types out of the box...