### PR TITLE
Remove WaitToWriteAsync

### DIFF
--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionConfigBuilder.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionConfigBuilder.cs
@@ -109,6 +109,7 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
         {
             if (DefaultPrefetch < 0)
                 throw new InvalidOperationException($"{nameof(DefaultPrefetch)} cannot be negative");
+            
             if (DefaultPrefetch > MessageConstants.MaxAmazonMessageCap)
                 throw new InvalidOperationException(
                     $"{nameof(DefaultPrefetch)} cannot be greater than {nameof(MessageConstants.MaxAmazonMessageCap)}");

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionConfigBuilder.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionConfigBuilder.cs
@@ -17,7 +17,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
         {
             DefaultBufferSize = MessageConstants.MaxAmazonMessageCap;
             DefaultReceiveBufferReadTimeout = TimeSpan.FromMinutes(5);
-            DefaultReceiveBufferWriteTimeout = TimeSpan.FromSeconds(2);
             DefaultMultiplexerCapacity = 100;
             DefaultPrefetch = 10;
             DefaultConcurrencyLimit = Environment.ProcessorCount * MessageConstants.ParallelHandlerExecutionPerCore;
@@ -26,22 +25,9 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
         public int DefaultPrefetch { get; private set; }
         public int DefaultBufferSize { get; private set; }
         public TimeSpan DefaultReceiveBufferReadTimeout { get; private set; }
-        public TimeSpan DefaultReceiveBufferWriteTimeout { get; private set; }
         public int DefaultConcurrencyLimit { get; private set; }
         public int DefaultMultiplexerCapacity { get; private set; }
         public ReceiveMiddleware SqsMiddleware { get; private set; }
-
-        /// <summary>
-        /// Specifies the default maximum amount of time for each queue in a <see cref="ISubscriptionGroup"/> to wait for
-        /// there to be room in the <see cref="IMultiplexer"/> before cancelling and trying again.
-        /// </summary>
-        /// <param name="receiveBufferWriteTimeout">The maximum amount of time to wait to write to the <see cref="IMultiplexer"/></param>
-        /// <returns>This builder object.</returns>
-        public SubscriptionConfigBuilder WithDefaultReceiveBufferWriteTimeout(TimeSpan receiveBufferWriteTimeout)
-        {
-            DefaultReceiveBufferWriteTimeout = receiveBufferWriteTimeout;
-            return this;
-        }
 
         /// <summary>
         /// Specifies the default maximum amount of time to wait for messages to be available on each SQS queue in a
@@ -127,8 +113,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
                 throw new InvalidOperationException(
                     $"{nameof(DefaultPrefetch)} cannot be greater than {nameof(MessageConstants.MaxAmazonMessageCap)}");
 
-            if (DefaultReceiveBufferWriteTimeout < TimeSpan.Zero)
-                throw new InvalidOperationException($"{nameof(DefaultReceiveBufferWriteTimeout)} cannot be negative");
             if (DefaultReceiveBufferReadTimeout < TimeSpan.Zero)
                 throw new InvalidOperationException($"{nameof(DefaultReceiveBufferReadTimeout)} cannot be negative");
 

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionConfigBuilder.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionConfigBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using JustSaying.Messaging.Channels.Multiplexer;
 using JustSaying.Messaging.MessageProcessingStrategies;
 using JustSaying.Messaging.Middleware;
 using ReceiveMiddleware =
@@ -45,6 +46,7 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
         /// <summary>
         /// Specifies the default maximum amount of time to wait for messages to be available on each SQS queue in a
         /// <see cref="ISubscriptionGroup"/> before resetting the connection.
+        /// Defaults to 5 minutes
         /// </summary>
         /// <param name="receiveBufferReadTimeout">The maximum amount of time to wait to read from each SQS queue</param>
         /// <returns>This builder object.</returns>
@@ -56,7 +58,8 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
 
         /// <summary>
         /// Specifies the default number of messages that may be buffered across all of the queues in this <see cref="ISubscriptionGroup"/>.
-        /// Note: This setting is shared across all queues in thiss group. For per-queue settings, see <see cref="WithBufferSize"/>
+        /// Note: This setting is shared across all queues in this group. For per-queue settings, see <see cref="WithDefaultBufferSize"/>
+        /// Defaults to 100
         /// </summary>
         /// <param name="multiplexerCapacity">The maximum multiplexer capacity</param>
         /// <returns>This builder object.</returns>
@@ -68,6 +71,7 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
 
         /// <summary>
         /// Specifies the default number of messages to try and fetch from SQS per attempt for each queue in a <see cref="ISubscriptionGroup"/>
+        /// Defaults to 10
         /// </summary>
         /// <param name="prefetch">the number of messages to load per request</param>
         /// <returns>This builder object.</returns>
@@ -79,6 +83,7 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
 
         /// <summary>
         /// Specifies the default maximum number of messages that may be processed at once by a <see cref="ISubscriptionGroup"/>.
+        /// Defaults to Environment.ProcessorCount * 4
         /// </summary>
         /// <param name="concurrencyLimit">The maximum number of messages to process at the same time</param>
         /// <returns>This builder object.</returns>
@@ -91,7 +96,7 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
         /// <summary>
         /// Specifies the default number of messages that will be buffered from SQS for each of the queues in a <see cref="ISubscriptionGroup"/>
         /// before waiting for them to drain into the <see cref="IMultiplexer"/>.
-        /// Note: This setting is per-queue. To set the shared buffer size for all queues, see <see cref="WithMultiplexerCapacity"/>
+        /// Note: This setting is per-queue. To set the shared buffer size for all queues, see <see cref="WithDefaultMultiplexerCapacity"/>
         /// </summary>
         /// <param name="bufferSize">The maximum number of messages for each queue to buffer</param>
         /// <returns>This builder object.</returns>
@@ -112,6 +117,29 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
         {
             SqsMiddleware = middleware;
             return this;
+        }
+
+        public void Validate()
+        {
+            if (DefaultPrefetch < 0)
+                throw new InvalidOperationException($"{nameof(DefaultPrefetch)} cannot be negative");
+            if (DefaultPrefetch > MessageConstants.MaxAmazonMessageCap)
+                throw new InvalidOperationException(
+                    $"{nameof(DefaultPrefetch)} cannot be greater than {nameof(MessageConstants.MaxAmazonMessageCap)}");
+
+            if (DefaultReceiveBufferWriteTimeout < TimeSpan.Zero)
+                throw new InvalidOperationException($"{nameof(DefaultReceiveBufferWriteTimeout)} cannot be negative");
+            if (DefaultReceiveBufferReadTimeout < TimeSpan.Zero)
+                throw new InvalidOperationException($"{nameof(DefaultReceiveBufferReadTimeout)} cannot be negative");
+
+            if (DefaultConcurrencyLimit < 0)
+                throw new InvalidOperationException($"{nameof(DefaultConcurrencyLimit)} cannot be negative");
+
+            if (DefaultMultiplexerCapacity < 0)
+                throw new InvalidOperationException($"{nameof(DefaultMultiplexerCapacity)} cannot be negative");
+
+            if (DefaultBufferSize < 0)
+                throw new InvalidOperationException($"{nameof(DefaultBufferSize)} cannot be negative");
         }
     }
 }

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroupConfigBuilder.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroupConfigBuilder.cs
@@ -17,7 +17,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
 
         private int? _bufferSize;
         private TimeSpan? _receiveBufferReadTimeout;
-        private TimeSpan? _receiveBufferWriteTimeout;
         private int? _concurrencyLimit;
         private int? _multiplexerCapacity;
         private int? _prefetch;
@@ -89,18 +88,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
         }
 
         /// <summary>
-        /// Specifies the maximum amount of time for each queue in this <see cref="ISubscriptionGroup"/> to wait for
-        /// there to be room in the <see cref="IMultiplexer"/> before cancelling and trying again.
-        /// </summary>
-        /// <param name="receiveBufferWriteTimeout">The maximum amount of time to wait to write to the <see cref="IMultiplexer"/></param>
-        /// <returns>This builder object.</returns>
-        public SubscriptionGroupConfigBuilder WithReceiveBufferWriteTimeout(TimeSpan receiveBufferWriteTimeout)
-        {
-            _receiveBufferWriteTimeout = receiveBufferWriteTimeout;
-            return this;
-        }
-
-        /// <summary>
         /// Specifies the number of messages that may be buffered across all of the queues in this <see cref="ISubscriptionGroup"/>.
         /// Note: This setting is shared across all queues in this group. For per-queue settings, see <see cref="WithBufferSize"/>
         /// </summary>
@@ -139,7 +126,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
                 _concurrencyLimit ?? defaults.DefaultConcurrencyLimit,
                 _bufferSize ?? defaults.DefaultBufferSize,
                 _receiveBufferReadTimeout ?? defaults.DefaultReceiveBufferReadTimeout,
-                _receiveBufferWriteTimeout ?? defaults.DefaultReceiveBufferWriteTimeout,
                 _multiplexerCapacity ?? defaults.DefaultMultiplexerCapacity,
                 _prefetch ?? defaults.DefaultPrefetch,
                 _sqsQueues);

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroupFactory.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroupFactory.cs
@@ -78,7 +78,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
                     subscriptionGroupSettings.Prefetch,
                     subscriptionGroupSettings.BufferSize,
                     subscriptionGroupSettings.ReceiveBufferReadTimeout,
-                    subscriptionGroupSettings.ReceiveBufferWriteTimeout,
                     queue,
                     defaults.SqsMiddleware ?? new DefaultSqsMiddleware(_loggerFactory.CreateLogger<DefaultSqsMiddleware>()),
                     _monitor,

--- a/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroupSettings.cs
+++ b/src/JustSaying/Messaging/Channels/SubscriptionGroups/SubscriptionGroupSettings.cs
@@ -11,7 +11,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
             int concurrencyLimit,
             int bufferSize,
             TimeSpan receiveBufferReadTimeout,
-            TimeSpan receiveBufferWriteTimeout,
             int multiplexerCapacity,
             int prefetch,
             IReadOnlyCollection<ISqsQueue> queues)
@@ -19,7 +18,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
             ConcurrencyLimit = concurrencyLimit;
             BufferSize = bufferSize;
             ReceiveBufferReadTimeout = receiveBufferReadTimeout;
-            ReceiveBufferWriteTimeout = receiveBufferWriteTimeout;
             MultiplexerCapacity = multiplexerCapacity;
             Prefetch = prefetch;
             Queues = queues;
@@ -29,7 +27,6 @@ namespace JustSaying.Messaging.Channels.SubscriptionGroups
         public int ConcurrencyLimit { get; }
         public int BufferSize { get; }
         public TimeSpan ReceiveBufferReadTimeout { get; }
-        public TimeSpan ReceiveBufferWriteTimeout { get; }
         public int MultiplexerCapacity { get; }
         public int Prefetch { get; }
         public string Name { get; }

--- a/src/JustSaying/MessagingConfig.cs
+++ b/src/JustSaying/MessagingConfig.cs
@@ -65,7 +65,7 @@ namespace JustSaying
                 throw new InvalidOperationException($"Config cannot have a null for the {nameof(MessageSubjectProvider)} property.");
             }
 
-            // Todo: validate the consumer config
+            SubscriptionConfigDefaults.Validate();
         }
     }
 }

--- a/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/ChannelsTests.cs
@@ -332,7 +332,6 @@ namespace JustSaying.UnitTests.Messaging.Channels
                 10,
                 10,
                 TimeSpan.FromSeconds(1),
-                TimeSpan.FromSeconds(1),
                 sqsQueue,
                 new DelegateMiddleware<GetMessagesContext, IList<Message>>(),
                 Substitute.For<IMessageMonitor>(),

--- a/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/BaseMessageReceiveBufferTests.cs
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/MessageReceiveBufferTests/BaseMessageReceiveBufferTests.cs
@@ -83,7 +83,6 @@ namespace JustSaying.UnitTests.Messaging.Channels.MessageReceiveBufferTests
                 10,
                 10,
                 TimeSpan.FromSeconds(1),
-                TimeSpan.FromSeconds(1),
                 Queue,
                 SqsMiddleware,
                 Monitor,


### PR DESCRIPTION
It was only used before so we could intermittently check if we needed to drain the buffer, but now we're just tearing everything down so we can just use the app's stopping token.