### PR TITLE
Remove IMessageBackoffStrategy from DI

### DIFF
--- a/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
+++ b/src/JustSaying/Messaging/Channels/Receive/MessageReceiveBuffer.cs
@@ -30,7 +30,6 @@ namespace JustSaying.Messaging.Channels.Receive
         private readonly ILogger _logger;
 
         private readonly HashSet<string> _requestMessageAttributeNames = new HashSet<string>();
-        private readonly string _backoffStrategyName;
 
         public ChannelReader<IQueueMessageContext> Reader => _channel.Reader;
 
@@ -44,8 +43,7 @@ namespace JustSaying.Messaging.Channels.Receive
             ISqsQueue sqsQueue,
             MiddlewareBase<ReceiveMessagesContext, IList<Message>> sqsMiddleware,
             IMessageMonitor monitor,
-            ILogger<IMessageReceiveBuffer> logger,
-            IMessageBackoffStrategy messageBackoffStrategy = null)
+            ILogger<IMessageReceiveBuffer> logger)
         {
             _prefetch = prefetch;
             _bufferSize = bufferSize;
@@ -56,14 +54,10 @@ namespace JustSaying.Messaging.Channels.Receive
             _sqsMiddleware = sqsMiddleware ?? throw new ArgumentNullException(nameof(sqsMiddleware));
             _monitor = monitor ?? throw new ArgumentNullException(nameof(monitor));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _backoffStrategyName = messageBackoffStrategy?.GetType()?.Name;
 
             _channel = Channel.CreateBounded<IQueueMessageContext>(bufferSize);
 
-            if (messageBackoffStrategy != null)
-            {
-                _requestMessageAttributeNames.Add(MessageSystemAttributeName.ApproximateReceiveCount);
-            }
+            _requestMessageAttributeNames.Add(MessageSystemAttributeName.ApproximateReceiveCount);
         }
 
         /// <summary>
@@ -174,7 +168,6 @@ namespace JustSaying.Messaging.Channels.Receive
                 _sqsQueueReader.QueueName,
                 Region = _sqsQueueReader.RegionSystemName,
                 Prefetch = _prefetch,
-                BackoffStrategyName = _backoffStrategyName,
             });
         }
     }

--- a/src/JustSaying/Messaging/Middleware/Backoff/BackoffMiddlewareBuilderExtensions.cs
+++ b/src/JustSaying/Messaging/Middleware/Backoff/BackoffMiddlewareBuilderExtensions.cs
@@ -13,13 +13,12 @@ namespace JustSaying.Messaging.Middleware.Backoff
         /// a <see cref="BackoffMiddleware"/> and add it to the pipeline.
         /// </summary>
         /// <param name="builder">The <see cref="HandlerMiddlewareBuilder"/> to add the middleware to.</param>
+        /// <param name="backoffStrategy">The <see cref="IMessageBackoffStrategy"/> to use to determine message visibility timeouts.</param>
         /// <returns>The current <see cref="HandlerMiddlewareBuilder"/>.</returns>
         /// <exception cref="ArgumentNullException">When the <see cref="HandlerMiddlewareBuilder"/> is null.</exception>
-        public static HandlerMiddlewareBuilder UseBackoff(this HandlerMiddlewareBuilder builder)
+        public static HandlerMiddlewareBuilder UseBackoff(this HandlerMiddlewareBuilder builder, IMessageBackoffStrategy backoffStrategy)
         {
             if (builder == null) throw new ArgumentNullException(nameof(builder));
-
-            var backoffStrategy = builder.ServiceResolver.ResolveService<IMessageBackoffStrategy>();
 
             var loggerFactory = builder.ServiceResolver.ResolveService<ILoggerFactory>();
             var monitor = builder.ServiceResolver.ResolveService<IMessageMonitor>();

--- a/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilderExtensions.cs
+++ b/src/JustSaying/Messaging/Middleware/Handle/HandlerMiddlewareBuilderExtensions.cs
@@ -67,10 +67,6 @@ namespace JustSaying.Messaging.Middleware
             if (handlerType == null) throw new ArgumentNullException(nameof(handlerType), "HandlerType is used here to");
 
             builder.UseMessageContextAccessor();
-            if (builder.ServiceResolver.ResolveOptionalService<IMessageBackoffStrategy>() != null)
-            {
-                builder.UseBackoff();
-            }
             builder.UseErrorHandler();
             builder.Use<LoggingMiddleware>();
             builder.UseStopwatch(handlerType);

--- a/tests/JustSaying.IntegrationTests/Fluent/Publishing/Approvals/WhenInterrogatingTheBus.Then_The_Interrogation_Result_Should_Be_Returned.approved.txt
+++ b/tests/JustSaying.IntegrationTests/Fluent/Publishing/Approvals/WhenInterrogatingTheBus.Then_The_Interrogation_Result_Should_Be_Returned.approved.txt
@@ -31,8 +31,7 @@
             "BufferSize": 10,
             "QueueName": "integrationTestQueueName",
             "Region": "eu-west-1",
-            "Prefetch": 10,
-            "BackoffStrategyName": null
+            "Prefetch": 10
           }
         ]
       }

--- a/tests/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
+++ b/tests/JustSaying.UnitTests/AwsTools/MessageHandling/MessageDispatcherTests/WhenDispatchingMessage.cs
@@ -14,6 +14,7 @@ using JustSaying.Messaging.MessageHandling;
 using JustSaying.Messaging.MessageProcessingStrategies;
 using JustSaying.Messaging.MessageSerialization;
 using JustSaying.Messaging.Middleware;
+using JustSaying.Messaging.Middleware.Backoff;
 using JustSaying.Messaging.Monitoring;
 using JustSaying.TestingFramework;
 using JustSaying.UnitTests.Messaging.Channels.Fakes;
@@ -148,12 +149,12 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
 
                 var handler = new InspectableHandler<SimpleMessage>();
 
-                var testResolver = new InMemoryServiceResolver(_outputHelper, _messageMonitor,
-                    sc => sc
-                        .AddSingleton<IHandlerAsync<SimpleMessage>>(handler)
-                        .AddSingleton(MessageBackoffStrategy));
+                var testResolver = new InMemoryServiceResolver(_outputHelper,
+                    _messageMonitor,
+                    sc => sc.AddSingleton<IHandlerAsync<SimpleMessage>>(handler));
 
                 var middleware = new HandlerMiddlewareBuilder(testResolver, testResolver)
+                    .UseBackoff(MessageBackoffStrategy)
                     .UseDefaults<SimpleMessage>(handler.GetType())
                     .Build();
 
@@ -193,12 +194,12 @@ namespace JustSaying.UnitTests.AwsTools.MessageHandling.MessageDispatcherTests
                     OnHandle = msg => throw _expectedException
                 };
 
-                var testResolver = new InMemoryServiceResolver(_outputHelper, _messageMonitor,
-                    sc => sc
-                        .AddSingleton<IHandlerAsync<SimpleMessage>>(handler)
-                        .AddSingleton(MessageBackoffStrategy));
+                var testResolver = new InMemoryServiceResolver(_outputHelper,
+                    _messageMonitor,
+                    sc => sc.AddSingleton<IHandlerAsync<SimpleMessage>>(handler));
 
                 var middleware = new HandlerMiddlewareBuilder(testResolver, testResolver)
+                    .UseBackoff(MessageBackoffStrategy)
                     .UseDefaults<SimpleMessage>(handler.GetType())
                     .Build();
 

--- a/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupTests/Approvals/WhenListeningWithMultipleGroups.SubscriptionGroups_OverridesDefaultSettingsCorrectly.approved.txt
+++ b/tests/JustSaying.UnitTests/Messaging/Channels/SubscriptionGroupTests/Approvals/WhenListeningWithMultipleGroups.SubscriptionGroups_OverridesDefaultSettingsCorrectly.approved.txt
@@ -12,8 +12,7 @@
           "BufferSize": 20,
           "QueueName": "EC159934-A30E-45B0-9186-78853F7D3BED",
           "Region": "fake-region",
-          "Prefetch": 5,
-          "BackoffStrategyName": null
+          "Prefetch": 5
         }
       ]
     },
@@ -29,8 +28,7 @@
           "BufferSize": 10,
           "QueueName": "C7506B3F-81DA-4898-82A5-C0293523592A",
           "Region": "fake-region",
-          "Prefetch": 10,
-          "BackoffStrategyName": null
+          "Prefetch": 10
         }
       ]
     }


### PR DESCRIPTION
This PR moves IMBS from DI and requires users to pass it into the backoff middleware when adding it to the pipeline instead.

This means you can now have separate IMBS's per subscription.

There is a downside to this though, which is that since we can no longer pull IMBS from DI, we can't see if one is registered so that we can know whether to pull in the `ApproximateReceiveCount` attribute. My solution here has been to always request it - how expensive can it be?